### PR TITLE
Configure Mend for GitHub Enterprise

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,0 +1,3 @@
+{
+  "settingsInheritedFrom": "whitesource-config/whitesource-config@master"
+}


### PR DESCRIPTION
Welcome to Mend for GitHub Enterprise! This is an onboarding PR to help you understand and configure settings before Mend starts scanning your repository for security vulnerabilities.

:vertical_traffic_light: Mend for GitHub Enterprise will start scanning your repository only once you merge this Pull Request. To disable Mend for GitHub Enterprise, simply close this Pull Request. 



---

### What to Expect

This PR contains a '.whitesource' configuration file which can be customized to your needs. If no changes were applied to this file, Mend for GitHub Enterprise will use the default configuration.

Before merging this PR, Make sure the [Issues tab is enabled](https://whitesource.atlassian.net/wiki/spaces/WD/pages/792461347/Enabling+the+Issues+Tab+for+a+GitHub+Enterprise+Repository). Once you merge this PR, Mend for GitHub Enterprise will scan your repository and create a GitHub Issue for every vulnerability detected in your repository. 

If you do not want a GitHub Issue to be created for each detected vulnerability, you can edit the '.whitesource' file and set the 'minSeverityLevel' parameter to 'NONE'. 

If [Mend Remediate](https://whitesource.atlassian.net/wiki/spaces/WD/pages/710444101/WhiteSource+Remediate) Workflow Rules are set on your repository (from the Mend 'Integrate' tab), Mend will also generate a fix Pull Request for relevant vulnerabilities.

---

:question: Got questions? Check out Mend for GitHub Enterprise [docs](https://whitesource.atlassian.net/wiki/spaces/WD/pages/765427987/WhiteSource+for+GitHub+Enterprise).
If you need any further assistance then you can also [request help here](https://whitesourcesoftware.force.com/CustomerCommunity/s).<!-- <WHITESOURCE>{ "installationId": "7974"}</WHITESOURCE> -->