### PR TITLE
fix(#49): button style and pressable feedback and migrate icons to 20

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -8,7 +8,6 @@ import TestIcons from './Views/Icons';
 import ThemeIcon from '@carbon/icons/es/color-palette/20';
 import LayoutIcon from '@carbon/icons/es/open-panel--left/20';
 import ResourcesIcon from '@carbon/icons/es/document/20';
-import ArrowLeftIcon from '@carbon/icons/es/arrow--left/16';
 import ComponentIcon from '@carbon/icons/es/view--mode-2/20';
 import TestWebHeader from './Views/WebHeader';
 import TestLandinView from './Views/LandingView';
@@ -200,7 +199,7 @@ export default class App extends React.Component {
         ? {
             text: pageNames[topView],
             onPress: this.clearView,
-            leftIcon: ArrowLeftIcon,
+            backButtonMode: true,
             iconSize: 15,
           }
         : undefined,

--- a/src/components/Accordion/index.tsx
+++ b/src/components/Accordion/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ViewProps, StyleProp, StyleSheet, ViewStyle, View, GestureResponderEvent, Pressable } from 'react-native';
 import { getColor } from '../../styles/colors';
-import { createIcon, styleReferenceBreaker } from '../../helpers';
+import { createIcon, pressableFeedbackStyle, styleReferenceBreaker } from '../../helpers';
 import ChevronDownIcon from '@carbon/icons/es/chevron--down/20';
 import ChevronUpIcon from '@carbon/icons/es/chevron--up/20';
 import { Text } from '../Text';
@@ -105,7 +105,7 @@ export class Accordion extends React.Component<AccordionProps> {
 
     return (
       <View style={styleReferenceBreaker(finalStyle, style)} {...(componentProps || {})}>
-        <Pressable style={this.styles.action} accessibilityLabel={title} accessibilityRole="togglebutton" onPress={this.toggleDropdown} disabled={disabled}>
+        <Pressable style={(state) => pressableFeedbackStyle(state, this.styles.action)} accessibilityLabel={title} accessibilityRole="togglebutton" onPress={this.toggleDropdown} disabled={disabled}>
           <Text style={this.styles.textItem} text={title} />
           {this.accordionIcon}
         </Pressable>

--- a/src/components/ActionSheet/index.tsx
+++ b/src/components/ActionSheet/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ActionSheetIOS, Platform, Pressable, ScrollView, StyleSheet, View, Modal as ReactModal, SafeAreaView } from 'react-native';
-import { styleReferenceBreaker } from '../../helpers';
+import { pressableFeedbackStyle, styleReferenceBreaker } from '../../helpers';
 import { modalPresentations } from '../../constants/constants';
 import { getColor } from '../../styles/colors';
 import { Overlay } from '../Overlay';
@@ -168,7 +168,7 @@ export class ActionSheet extends React.Component<ActionSheetProps> {
 
                     return (
                       <Pressable
-                        style={finalStyle}
+                        style={(state) => pressableFeedbackStyle(state, finalStyle)}
                         accessibilityLabel={item.text}
                         key={index}
                         onPress={() => {
@@ -182,7 +182,7 @@ export class ActionSheet extends React.Component<ActionSheetProps> {
                 </ScrollView>
               </View>
               <Pressable
-                style={this.styles.cancelButton}
+                style={(state) => pressableFeedbackStyle(state, this.styles.cancelButton)}
                 accessibilityLabel={cancel.text}
                 onPress={() => {
                   cancel.onPress();

--- a/src/components/BaseTextInputs/index.tsx
+++ b/src/components/BaseTextInputs/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { NativeSyntheticEvent, StyleProp, StyleSheet, TextInputFocusEventData, View, ViewStyle, TextInput as ReactTextInput, TextInputProps as ReactTextInputProps, Pressable, Platform } from 'react-native';
-import { createIcon, styleReferenceBreaker } from '../../helpers';
+import { createIcon, pressableFeedbackStyle, styleReferenceBreaker } from '../../helpers';
 import { getColor } from '../../styles/colors';
 import { Button } from '../Button';
 import { Text, TextBreakModes } from '../Text';
@@ -156,7 +156,7 @@ export const getTextInputStyle = (light?: boolean) => {
       marginTop: 14,
     },
     numberActionsButton: {
-      padding: 13,
+      padding: 14,
     },
   });
 };
@@ -245,7 +245,7 @@ export class BaseTextInput extends React.Component<{ type: 'text' | 'text-area' 
       errorIconStyle.paddingLeft = 0;
     }
 
-    return <View style={errorIconStyle}>{createIcon(WarningFilledIcon, 22, 22, getColor('supportError'))}</View>;
+    return <View style={errorIconStyle}>{createIcon(WarningFilledIcon, 20, 20, getColor('supportError'))}</View>;
   }
 
   private incrementNumber = (): void => {
@@ -274,8 +274,8 @@ export class BaseTextInput extends React.Component<{ type: 'text' | 'text-area' 
     const getPressable = (onPress: () => void, pressableDisabled: boolean, icon: unknown): React.ReactNode => {
       const finalDisabled = pressableDisabled || disabled || false;
       return (
-        <Pressable style={this.styles.numberActionsButton} onPress={onPress} disabled={finalDisabled}>
-          {createIcon(icon, 22, 22, finalDisabled ? getColor('iconDisabled') : getColor('iconPrimary'))}
+        <Pressable style={(state) => pressableFeedbackStyle(state, this.styles.numberActionsButton)} onPress={onPress} disabled={finalDisabled}>
+          {createIcon(icon, 20, 20, finalDisabled ? getColor('iconDisabled') : getColor('iconPrimary'))}
         </Pressable>
       );
     };

--- a/src/components/BottomNavigationBar/index.tsx
+++ b/src/components/BottomNavigationBar/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ViewProps, StyleProp, StyleSheet, ViewStyle, Pressable, View } from 'react-native';
 import { getColor } from '../../styles/colors';
-import { createIcon, styleReferenceBreaker } from '../../helpers';
+import { createIcon, pressableFeedbackStyle, styleReferenceBreaker } from '../../helpers';
 import type { NavigationButton } from '../../types/navigation';
 import { Text } from '../Text';
 
@@ -63,7 +63,7 @@ export class BottomNavigationBar extends React.Component<BottomNavigationBarProp
       }
 
       return (
-        <Pressable key={index} style={finalStyles} disabled={item.disabled} onPress={item.onPress} onLongPress={item.onLongPress} accessibilityLabel={item.text} accessibilityRole="tab" {...(item.componentProps || {})}>
+        <Pressable key={index} style={(state) => pressableFeedbackStyle(state, finalStyles)} disabled={item.disabled} onPress={item.onPress} onLongPress={item.onLongPress} accessibilityLabel={item.text} accessibilityRole="tab" {...(item.componentProps || {})}>
           <View style={this.styles.icon}>{createIcon(item.icon, 20, 20, finalColor)}</View>
           <Text style={styleReferenceBreaker(useActiveText ? this.styles.textActive : {}, { color: finalColor, textAlign: 'center' })} text={item.text} type="label-01" breakMode="tail" />
         </Pressable>

--- a/src/components/BottomToolbar/index.tsx
+++ b/src/components/BottomToolbar/index.tsx
@@ -28,13 +28,12 @@ export class BottomToolbar extends React.Component<BottomToolbarProps> {
         borderTopColor: getColor('borderSubtle01'),
         borderTopWidth: 1,
       },
-      itemTextStyle: {
-        padding: 16,
-        paddingTop: 13,
-        paddingBottom: 0,
-      },
+      itemTextStyle: {},
       itemIconStyle: {
         width: 48,
+      },
+      linkStyle: {
+        padding: 13,
       },
     });
   }
@@ -67,7 +66,7 @@ export class BottomToolbar extends React.Component<BottomToolbarProps> {
 
       return (
         <View style={finalStyles} key={index}>
-          {iconMode ? <Button kind="ghost" overrideColor={finalColor} disabled={item.disabled} icon={item.icon} iconOnlyMode={true} text={item.text} onPress={item.onPress} onLongPress={item.onLongPress} /> : <Link disabled={item.disabled} textStyle={{ textAlign: item.alignItem || 'center' }} text={item.text} onPress={item.onPress} onLongPress={item.onLongPress} />}
+          {iconMode ? <Button kind="ghost" overrideColor={finalColor} disabled={item.disabled} icon={item.icon} iconOnlyMode={true} text={item.text} onPress={item.onPress} onLongPress={item.onLongPress} /> : <Link disabled={item.disabled} style={this.styles.linkStyle} textStyle={{ textAlign: item.alignItem || 'center' }} text={item.text} onPress={item.onPress} onLongPress={item.onLongPress} />}
         </View>
       );
     });

--- a/src/components/BottomToolbarPrimaryAction/index.tsx
+++ b/src/components/BottomToolbarPrimaryAction/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ViewProps, StyleProp, StyleSheet, ViewStyle, View, GestureResponderEvent, Pressable } from 'react-native';
 import { getColor } from '../../styles/colors';
-import { createIcon, styleReferenceBreaker } from '../../helpers';
+import { createIcon, pressableFeedbackStyle, styleReferenceBreaker } from '../../helpers';
 import type { ToolbarButton } from '../../types/navigation';
 import { Button } from '../Button';
 import { Link } from '../Link';
@@ -59,12 +59,12 @@ export class BottomToolbarPrimaryAction extends React.Component<BottomToolbarPri
       },
       itemTextStyle: {
         flex: 1,
-        padding: 16,
-        paddingTop: 13,
-        paddingBottom: 0,
       },
       itemIconStyle: {
         width: 48,
+      },
+      linkStyle: {
+        padding: 13,
       },
     });
   }
@@ -91,7 +91,7 @@ export class BottomToolbarPrimaryAction extends React.Component<BottomToolbarPri
 
           return (
             <View style={finalStyles} key={index}>
-              {iconMode ? <Button kind="ghost" overrideColor={finalColor} disabled={item.disabled} icon={item.icon} iconOnlyMode={true} text={item.text} onPress={item.onPress} onLongPress={item.onLongPress} /> : <Link disabled={item.disabled} text={item.text} onPress={item.onPress} onLongPress={item.onLongPress} />}
+              {iconMode ? <Button kind="ghost" overrideColor={finalColor} disabled={item.disabled} icon={item.icon} iconOnlyMode={true} text={item.text} onPress={item.onPress} onLongPress={item.onLongPress} /> : <Link style={this.styles.linkStyle} disabled={item.disabled} text={item.text} onPress={item.onPress} onLongPress={item.onLongPress} />}
             </View>
           );
         })}
@@ -108,7 +108,7 @@ export class BottomToolbarPrimaryAction extends React.Component<BottomToolbarPri
     }
 
     return (
-      <Pressable disabled={disabled} style={finalStyles} onPress={onPress} onLongPress={onLongPress} accessibilityLabel={text} accessibilityRole="button">
+      <Pressable disabled={disabled} style={(state) => pressableFeedbackStyle(state, finalStyles)} onPress={onPress} onLongPress={onLongPress} accessibilityLabel={text} accessibilityRole="button">
         {createIcon(icon, 24, 24, getColor(disabled ? 'textOnColorDisabled' : 'textOnColor'))}
       </Pressable>
     );

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { GestureResponderEvent, Keyboard, Pressable, PressableProps, StyleProp, StyleSheet, TextStyle, View, ViewStyle } from 'react-native';
 import type { CarbonIcon } from '../../types/shared';
-import { createIcon, styleReferenceBreaker } from '../../helpers';
+import { createIcon, pressableFeedbackStyle, styleReferenceBreaker } from '../../helpers';
 import { getColor } from '../../styles/colors';
 import { Text, TextTypes } from '../Text';
 
@@ -46,8 +46,8 @@ export class Button extends React.Component<ButtonProps> {
     return StyleSheet.create({
       iconStyle: {
         position: 'absolute',
-        top: 13,
-        right: 13,
+        top: 14,
+        right: 14,
       },
     });
   }
@@ -173,9 +173,9 @@ export class Button extends React.Component<ButtonProps> {
     const { text, disabled, onLongPress, componentProps, icon, iconOnlyMode, textType } = this.props;
 
     return (
-      <Pressable disabled={disabled} style={this.buttonStyle} accessibilityLabel={text} accessibilityRole="button" onPress={this.onPress} onLongPress={onLongPress} {...(componentProps || {})}>
+      <Pressable disabled={disabled} style={(state) => pressableFeedbackStyle(state, this.buttonStyle)} accessibilityLabel={text} accessibilityRole="button" onPress={this.onPress} onLongPress={onLongPress} {...(componentProps || {})}>
         {!iconOnlyMode && <Text type={textType || 'body-compact-02'} style={this.textStyle} text={text} breakMode="tail" />}
-        {icon && <View style={this.styles.iconStyle}>{createIcon(icon, 22, 22, this.iconTextColor)}</View>}
+        {icon && <View style={this.styles.iconStyle}>{createIcon(icon, 20, 20, this.iconTextColor)}</View>}
       </Pressable>
     );
   }

--- a/src/components/Checkbox/index.tsx
+++ b/src/components/Checkbox/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { GestureResponderEvent, Pressable, PressableProps, StyleProp, StyleSheet, TextStyle, View, ViewStyle } from 'react-native';
 import { defaultText } from '../../constants/defaultText';
-import { createIcon, styleReferenceBreaker } from '../../helpers';
+import { createIcon, pressableFeedbackStyle, styleReferenceBreaker } from '../../helpers';
 import { getColor } from '../../styles/colors';
 import { Text } from '../Text';
 import CheckboxIcon from '@carbon/icons/es/checkbox/20';
@@ -81,7 +81,7 @@ export class Checkbox extends React.Component<CheckboxProps> {
     const { disabled, componentProps, label, checkboxText, hideLabel, style } = this.props;
 
     return (
-      <Pressable style={styleReferenceBreaker(this.styles.wrapper, style)} disabled={disabled} accessibilityLabel={checkboxText || defaultText.checkbox} accessibilityHint={label} accessibilityRole="checkbox" onPress={this.onPress} onLongPress={this.onLongPress} {...(componentProps || {})}>
+      <Pressable style={(state) => pressableFeedbackStyle(state, styleReferenceBreaker(this.styles.wrapper, style))} disabled={disabled} accessibilityLabel={checkboxText || defaultText.checkbox} accessibilityHint={label} accessibilityRole="checkbox" onPress={this.onPress} onLongPress={this.onLongPress} {...(componentProps || {})}>
         {this.checkbox}
         {!hideLabel && <Text type="body-compact-02" style={this.textStyle} text={label} />}
       </Pressable>

--- a/src/components/ContentSwitcher/index.tsx
+++ b/src/components/ContentSwitcher/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ViewProps, StyleProp, StyleSheet, ViewStyle, View, Pressable } from 'react-native';
 import { getColor } from '../../styles/colors';
-import { styleReferenceBreaker } from '../../helpers';
+import { pressableFeedbackStyle, styleReferenceBreaker } from '../../helpers';
 import { Text, TextBreakModes, TextTypes } from '../Text';
 
 export type SwitcherItem = {
@@ -99,7 +99,7 @@ export class ContentSwitcher extends React.Component<ContentSwitcherProps> {
     }
 
     return (
-      <Pressable key={index} disabled={item.disabled} onPress={() => this.changeItem(item, index)} style={finalStyle} accessibilityLabel={item.text} accessibilityRole="menuitem">
+      <Pressable key={index} disabled={item.disabled} onPress={() => this.changeItem(item, index)} style={(state) => pressableFeedbackStyle(state, finalStyle)} accessibilityLabel={item.text} accessibilityRole="menuitem">
         <Text type={item.textType || 'body-compact-01'} style={textStyle} breakMode={item.textBreakMode} text={item.text} />
       </Pressable>
     );

--- a/src/components/DataTable/DataTableCell.tsx
+++ b/src/components/DataTable/DataTableCell.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { StyleProp, StyleSheet, ViewStyle, GestureResponderEvent, Pressable, ViewProps, View } from 'react-native';
 import { getColor } from '../../styles/colors';
-import { styleReferenceBreaker } from '../../helpers';
+import { pressableFeedbackStyle, styleReferenceBreaker } from '../../helpers';
 import { Text, TextBreakModes } from '../Text';
 
 export type DataTableCellProps = {
@@ -66,7 +66,6 @@ export class DataTableCell extends React.Component<DataTableCellProps> {
     finalStyles.maxWidth = width;
 
     const finalProps = {
-      style: finalStyles,
       ...(componentProps || {}),
       onPress: onPress,
       onLongPress: onLongPress,
@@ -74,9 +73,17 @@ export class DataTableCell extends React.Component<DataTableCellProps> {
     };
 
     if (typeof onPress === 'function' || typeof onLongPress === 'function') {
-      return <Pressable {...finalProps}>{this.content}</Pressable>;
+      return (
+        <Pressable {...finalProps} style={(state) => pressableFeedbackStyle(state, finalStyles)}>
+          {this.content}
+        </Pressable>
+      );
     } else {
-      return <View {...finalProps}>{this.content}</View>;
+      return (
+        <View {...finalProps} style={finalStyles}>
+          {this.content}
+        </View>
+      );
     }
   }
 }

--- a/src/components/DataTable/DataTableRow.tsx
+++ b/src/components/DataTable/DataTableRow.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { StyleProp, StyleSheet, ViewStyle, GestureResponderEvent, Pressable, PressableProps } from 'react-native';
-import { styleReferenceBreaker } from '../../helpers';
+import { pressableFeedbackStyle, styleReferenceBreaker } from '../../helpers';
 
 export type DataTableRowProps = {
   /** Content of the row. Should be list of <DataTableCell />. */
@@ -34,7 +34,7 @@ export class DataTableRow extends React.Component<DataTableRowProps> {
     const finalStyles = styleReferenceBreaker(this.styles.wrapper, style);
 
     return (
-      <Pressable style={finalStyles} {...(componentProps || {})} onPress={onPress} onLongPress={onLongPress} accessibilityLabel={rowText}>
+      <Pressable style={(state) => pressableFeedbackStyle(state, finalStyles)} {...(componentProps || {})} onPress={onPress} onLongPress={onLongPress} accessibilityLabel={rowText}>
         {children}
       </Pressable>
     );

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ViewProps, StyleProp, StyleSheet, ViewStyle, View, Pressable, Modal as ReactModal, SafeAreaView } from 'react-native';
 import { getColor } from '../../styles/colors';
-import { createIcon, styleReferenceBreaker } from '../../helpers';
+import { createIcon, pressableFeedbackStyle, styleReferenceBreaker } from '../../helpers';
 import { Menu } from '../Menu';
 import { getTextInputStyle } from '../BaseTextInputs';
 import { Text, TextBreakModes, TextTypes } from '../Text';
@@ -81,8 +81,8 @@ export class Dropdown extends React.Component<DropdownProps> {
       },
       iconStyle: {
         position: 'absolute',
-        top: 12,
-        right: 12,
+        top: 13,
+        right: 13,
       },
       dropdownText: {
         color: this.itemColor,
@@ -99,7 +99,7 @@ export class Dropdown extends React.Component<DropdownProps> {
   private get dropdownIcon(): React.ReactNode {
     const { open } = this.state;
 
-    return <View style={this.styles.iconStyle}>{createIcon(open ? ChevronUpIcon : ChevronDownIcon, 22, 22, this.itemColor)}</View>;
+    return <View style={this.styles.iconStyle}>{createIcon(open ? ChevronUpIcon : ChevronDownIcon, 20, 20, this.itemColor)}</View>;
   }
 
   private toggleDropdown = (): void => {
@@ -129,7 +129,7 @@ export class Dropdown extends React.Component<DropdownProps> {
       <View style={styleReferenceBreaker(this.styles.wrapper, style)} accessibilityRole="menu" {...(componentProps || {})}>
         {!!label && <Text style={this.textInputStyles.label} type="label-02" text={label} />}
         <View style={this.styles.innerWrapper}>
-          <Pressable disabled={disabled} style={finalStyle} onPress={this.toggleDropdown}>
+          <Pressable disabled={disabled} style={(state) => pressableFeedbackStyle(state, finalStyle)} onPress={this.toggleDropdown}>
             <Text text={value} style={this.styles.dropdownText} />
             {this.dropdownIcon}
           </Pressable>

--- a/src/components/FileUploaderItem/index.tsx
+++ b/src/components/FileUploaderItem/index.tsx
@@ -48,8 +48,8 @@ export class FileUploaderItem extends React.Component<FileUploaderItemProps> {
         flex: 1,
       },
       indicator: {
-        paddingLeft: 12,
-        paddingTop: 13,
+        paddingLeft: 13,
+        paddingTop: 14,
         height: 48,
         width: 48,
       },
@@ -74,7 +74,7 @@ export class FileUploaderItem extends React.Component<FileUploaderItemProps> {
     const { status, invalid } = this.props;
 
     if (invalid) {
-      return <View style={this.styles.indicator}>{createIcon(WarningFilledIcon, 22, 22, getColor('supportError'))}</View>;
+      return <View style={this.styles.indicator}>{createIcon(WarningFilledIcon, 20, 20, getColor('supportError'))}</View>;
     } else if (status === 'uploading') {
       return (
         <View style={this.styles.indicator}>
@@ -82,7 +82,7 @@ export class FileUploaderItem extends React.Component<FileUploaderItemProps> {
         </View>
       );
     } else if (status === 'complete') {
-      return <View style={this.styles.indicator}>{createIcon(CheckmarkFilledIcon, 22, 22, getColor('supportInfo'))}</View>;
+      return <View style={this.styles.indicator}>{createIcon(CheckmarkFilledIcon, 20, 20, getColor('supportInfo'))}</View>;
     }
 
     return null;

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { GestureResponderEvent, Keyboard, Pressable, PressableProps, StyleProp, StyleSheet, TextStyle, View, ViewStyle } from 'react-native';
 import type { CarbonIcon } from '../../types/shared';
-import { createIcon, styleReferenceBreaker } from '../../helpers';
+import { createIcon, pressableFeedbackStyle, styleReferenceBreaker } from '../../helpers';
 import { getColor } from '../../styles/colors';
 import { Text, TextBreakModes, TextTypes } from '../Text';
 
@@ -20,6 +20,8 @@ export type LinkProps = {
   textType?: TextTypes;
   /** Break mode for text. Default is to wrap text */
   textBreakMode?: TextBreakModes;
+  /** Indicate if back button usage should be used */
+  backButtonMode?: boolean;
   /** onPress event */
   onPress?: (event: GestureResponderEvent) => void;
   /** onLongPress event */
@@ -61,6 +63,10 @@ export class Link extends React.Component<LinkProps> {
         marginLeft: 4,
         height: iconSize || 20,
       },
+      backArrowStyle: {
+        paddingRight: 2,
+        color: this.textIconColor,
+      },
     });
   }
 
@@ -87,11 +93,12 @@ export class Link extends React.Component<LinkProps> {
   };
 
   render(): React.ReactNode {
-    const { text, disabled, onLongPress, componentProps, textType, style, textBreakMode, leftIcon, rightIcon, iconSize } = this.props;
+    const { text, disabled, onLongPress, componentProps, textType, style, textBreakMode, leftIcon, rightIcon, iconSize, backButtonMode } = this.props;
 
     return (
-      <Pressable disabled={disabled} style={styleReferenceBreaker(this.styles.wrapper, style)} accessibilityLabel={text} accessibilityRole="link" onPress={this.onPress} onLongPress={onLongPress} {...(componentProps || {})}>
-        {!!leftIcon && <View style={this.styles.leftIcon}>{createIcon(leftIcon, iconSize || 20, iconSize || 20, this.textIconColor)}</View>}
+      <Pressable disabled={disabled} style={(state) => pressableFeedbackStyle(state, styleReferenceBreaker(this.styles.wrapper, style))} accessibilityLabel={text} accessibilityRole="link" onPress={this.onPress} onLongPress={onLongPress} {...(componentProps || {})}>
+        {!!(leftIcon && !backButtonMode) && <View style={this.styles.leftIcon}>{createIcon(leftIcon, iconSize || 20, iconSize || 20, this.textIconColor)}</View>}
+        {backButtonMode && <Text type={textType} style={this.styles.backArrowStyle} text={'\u2190'} />}
         <Text type={textType} style={this.textStyle} text={text} breakMode={textBreakMode} />
         {!!rightIcon && <View style={this.styles.rightIcon}>{createIcon(rightIcon, iconSize || 20, iconSize || 20, this.textIconColor)}</View>}
       </Pressable>

--- a/src/components/MenuItem/index.tsx
+++ b/src/components/MenuItem/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { GestureResponderEvent, Keyboard, Pressable, PressableProps, StyleProp, StyleSheet, TextStyle, ViewStyle } from 'react-native';
-import { styleReferenceBreaker } from '../../helpers';
+import { pressableFeedbackStyle, styleReferenceBreaker } from '../../helpers';
 import { getColor } from '../../styles/colors';
 import { Text, TextBreakModes, TextTypes } from '../Text';
 
@@ -63,7 +63,7 @@ export class MenuItem extends React.Component<MenuItemProps> {
     const { text, disabled, onLongPress, componentProps, textType, style, textBreakMode } = this.props;
 
     return (
-      <Pressable disabled={disabled} style={styleReferenceBreaker(this.styles.wrapper, style)} accessibilityLabel={text} accessibilityRole="menuitem" onPress={this.onPress} onLongPress={onLongPress} {...(componentProps || {})}>
+      <Pressable disabled={disabled} style={(state) => pressableFeedbackStyle(state, styleReferenceBreaker(this.styles.wrapper, style))} accessibilityLabel={text} accessibilityRole="menuitem" onPress={this.onPress} onLongPress={onLongPress} {...(componentProps || {})}>
         <Text breakMode={textBreakMode} type={textType} style={this.textStyle} text={text} />
       </Pressable>
     );

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -5,6 +5,7 @@ import { modalPresentations } from '../../constants/constants';
 import { getColor } from '../../styles/colors';
 import { Overlay } from '../Overlay';
 import { Text } from '../Text';
+import { pressableFeedbackStyle } from '../../helpers';
 
 export type ModalProps = {
   /** Title to show */
@@ -124,12 +125,12 @@ export class Modal extends React.Component<ModalProps> {
             {(hasPrimary || hasSecondary) && (
               <View style={this.styles.actions}>
                 {hasSecondary && (
-                  <Pressable onPress={secondaryActionOnPress} style={this.styles.secondaryButton} accessibilityLabel={secondaryActionText} accessibilityRole="button">
+                  <Pressable onPress={secondaryActionOnPress} style={(state) => pressableFeedbackStyle(state, this.styles.secondaryButton)} accessibilityLabel={secondaryActionText} accessibilityRole="button">
                     <Text style={this.styles.buttonText} text={secondaryActionText} />
                   </Pressable>
                 )}
                 {hasPrimary && (
-                  <Pressable onPress={primaryActionOnPress} style={this.styles.primaryButton} accessibilityLabel={primaryActionText} accessibilityRole="button">
+                  <Pressable onPress={primaryActionOnPress} style={(state) => pressableFeedbackStyle(state, this.styles.primaryButton)} accessibilityLabel={primaryActionText} accessibilityRole="button">
                     <Text style={this.styles.buttonText} text={primaryActionText} />
                   </Pressable>
                 )}

--- a/src/components/NavigationListItem/index.tsx
+++ b/src/components/NavigationListItem/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { GestureResponderEvent, Keyboard, Pressable, PressableProps, StyleProp, StyleSheet, View, ViewStyle } from 'react-native';
 import type { CarbonIcon } from '../../types/shared';
-import { createIcon, styleReferenceBreaker } from '../../helpers';
+import { createIcon, pressableFeedbackStyle, styleReferenceBreaker } from '../../helpers';
 import { getColor } from '../../styles/colors';
 import { Text, TextBreakModes } from '../Text';
 import ChevronRightIcon from '@carbon/icons/es/chevron--right/20';
@@ -123,7 +123,7 @@ export class NavigationListItem extends React.Component<NavigationListItemProps>
     }
 
     return (
-      <Pressable disabled={disabled} style={styleReferenceBreaker(finalStyle, style)} accessibilityLabel={text} accessibilityRole="button" onPress={this.onPress} onLongPress={onLongPress} {...(componentProps || {})}>
+      <Pressable disabled={disabled} style={(state) => pressableFeedbackStyle(state, styleReferenceBreaker(finalStyle, style))} accessibilityLabel={text} accessibilityRole="button" onPress={this.onPress} onLongPress={onLongPress} {...(componentProps || {})}>
         {!!leftIcon && <View style={this.styles.leftIcon}>{createIcon(leftIcon, 20, 20, this.textIconColor)}</View>}
         {this.contentArea}
         {!!rightIcon && <View style={this.styles.rightIcon}>{createIcon(rightIcon, 20, 20, this.textIconColor)}</View>}

--- a/src/components/Notification/index.tsx
+++ b/src/components/Notification/index.tsx
@@ -133,14 +133,14 @@ export class Notification extends React.Component<NotificationProps> {
 
     switch (kind) {
       case 'error':
-        return createIcon(ErrorIcon, 22, 22, this.accentColor);
+        return createIcon(ErrorIcon, 20, 20, this.accentColor);
       case 'warning':
-        return createIcon(WarningIcon, 22, 22, this.accentColor);
+        return createIcon(WarningIcon, 20, 20, this.accentColor);
       case 'success':
-        return createIcon(SuccessIcon, 22, 22, this.accentColor);
+        return createIcon(SuccessIcon, 20, 20, this.accentColor);
       case 'info':
       default:
-        return createIcon(InfoIcon, 22, 22, this.accentColor);
+        return createIcon(InfoIcon, 20, 20, this.accentColor);
     }
   }
 

--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Pressable, ScrollView, StyleProp, StyleSheet, ViewProps, ViewStyle } from 'react-native';
 import { getColor } from '../../styles/colors';
-import { createIcon, styleReferenceBreaker } from '../../helpers';
+import { createIcon, pressableFeedbackStyle, styleReferenceBreaker } from '../../helpers';
 import { defaultText } from '../../constants/defaultText';
 import CircleIcon from '@carbon/icons/es/circle--solid/20';
 
@@ -50,7 +50,7 @@ export class Pagination extends React.Component<PaginationProps> {
     const page = index + 1;
 
     return (
-      <Pressable style={this.styles.item} key={index} onPress={() => this.changePage(page)} accessibilityLabel={String(page)}>
+      <Pressable style={(state) => pressableFeedbackStyle(state, this.styles.item)} key={index} onPress={() => this.changePage(page)} accessibilityLabel={String(page)}>
         {createIcon(CircleIcon, 8, 8, currentPage === page ? getColor('buttonTertiary') : getColor('iconOnColorDisabled'))}
       </Pressable>
     );

--- a/src/components/ProgressIndicator/index.tsx
+++ b/src/components/ProgressIndicator/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ViewProps, StyleProp, StyleSheet, ViewStyle, View, GestureResponderEvent, Pressable } from 'react-native';
 import { getColor } from '../../styles/colors';
-import { createIcon, styleReferenceBreaker } from '../../helpers';
+import { createIcon, pressableFeedbackStyle, styleReferenceBreaker } from '../../helpers';
 import ChevronDownIcon from '@carbon/icons/es/chevron--down/20';
 import ChevronUpIcon from '@carbon/icons/es/chevron--up/20';
 import CheckmarkIcon from '@carbon/icons/es/checkmark--outline/20';
@@ -80,6 +80,7 @@ export class ProgressIndicator extends React.Component<ProgressIndicatorProps> {
       mainText: {
         color: this.itemColor,
         flex: 1,
+        minWidth: 100,
       },
       subText: {
         color: this.itemColor,
@@ -90,26 +91,26 @@ export class ProgressIndicator extends React.Component<ProgressIndicatorProps> {
   private get accordionIcon(): React.ReactNode {
     const { open } = this.state;
 
-    return <View style={this.styles.iconStyle}>{createIcon(open ? ChevronUpIcon : ChevronDownIcon, 22, 22, this.itemColor)}</View>;
+    return <View style={this.styles.iconStyle}>{createIcon(open ? ChevronUpIcon : ChevronDownIcon, 20, 20, this.itemColor)}</View>;
   }
 
   private get stepIcon(): React.ReactNode {
     const { status } = this.props;
-    let icon = createIcon(PendingIcon, 22, 22, getColor('interactive'));
+    let icon = createIcon(PendingIcon, 20, 20, getColor('interactive'));
 
     switch (status) {
       case 'complete':
-        icon = createIcon(CheckmarkIcon, 22, 22, getColor('interactive'));
+        icon = createIcon(CheckmarkIcon, 20, 20, getColor('interactive'));
         break;
       case 'in-progress':
-        icon = createIcon(ActiveIcon, 22, 22, getColor('interactive'));
+        icon = createIcon(ActiveIcon, 20, 20, getColor('interactive'));
         break;
       case 'invalid':
-        icon = createIcon(ErrorIcon, 22, 22, getColor('supportError'));
+        icon = createIcon(ErrorIcon, 20, 20, getColor('supportError'));
         break;
       case 'pending':
       default:
-        icon = createIcon(PendingIcon, 22, 22, getColor('interactive'));
+        icon = createIcon(PendingIcon, 20, 20, getColor('interactive'));
     }
 
     return <View style={this.styles.statusIcon}>{icon}</View>;
@@ -148,7 +149,7 @@ export class ProgressIndicator extends React.Component<ProgressIndicatorProps> {
 
     return (
       <View style={styleReferenceBreaker(finalStyle, style)} {...(componentProps || {})}>
-        <Pressable style={this.styles.action} accessibilityLabel={title} accessibilityHint={subText} accessibilityRole="togglebutton" onPress={this.toggleDropdown} disabled={disabled}>
+        <Pressable style={(state) => pressableFeedbackStyle(state, this.styles.action)} accessibilityLabel={title} accessibilityHint={subText} accessibilityRole="togglebutton" onPress={this.toggleDropdown} disabled={disabled}>
           {this.stepIcon}
           <View style={this.styles.actionText}>
             <Text style={this.styles.mainText} text={title} />

--- a/src/components/RadioButton/index.tsx
+++ b/src/components/RadioButton/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { GestureResponderEvent, Pressable, PressableProps, StyleProp, StyleSheet, TextStyle, View, ViewStyle } from 'react-native';
 import { defaultText } from '../../constants/defaultText';
-import { createIcon, styleReferenceBreaker } from '../../helpers';
+import { createIcon, pressableFeedbackStyle, styleReferenceBreaker } from '../../helpers';
 import { getColor } from '../../styles/colors';
 import { Text } from '../Text';
 import RadioButtonIcon from '@carbon/icons/es/radio-button/20';
@@ -81,7 +81,7 @@ export class RadioButton extends React.Component<RadioButtonProps> {
     const { disabled, componentProps, label, radioButtonText, hideLabel, style } = this.props;
 
     return (
-      <Pressable style={styleReferenceBreaker(this.styles.wrapper, style)} disabled={disabled} accessibilityLabel={radioButtonText || defaultText.radioButton} accessibilityHint={label} accessibilityRole="radio" onPress={this.onPress} onLongPress={this.onLongPress} {...(componentProps || {})}>
+      <Pressable style={(state) => pressableFeedbackStyle(state, styleReferenceBreaker(this.styles.wrapper, style))} disabled={disabled} accessibilityLabel={radioButtonText || defaultText.radioButton} accessibilityHint={label} accessibilityRole="radio" onPress={this.onPress} onLongPress={this.onLongPress} {...(componentProps || {})}>
         {this.radioButton}
         {!hideLabel && <Text type="body-compact-02" style={this.textStyle} text={label} />}
       </Pressable>

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ViewProps, StyleProp, StyleSheet, ViewStyle, View, Pressable, ScrollView } from 'react-native';
 import { getColor } from '../../styles/colors';
-import { styleReferenceBreaker } from '../../helpers';
+import { pressableFeedbackStyle, styleReferenceBreaker } from '../../helpers';
 import { Text } from '../Text';
 
 export type TabItem = {
@@ -88,7 +88,7 @@ export class Tabs extends React.Component<TabsProps> {
     }
 
     return (
-      <Pressable key={index} disabled={item.disabled} onPress={() => this.changeItem(item, index)} style={finalStyle} accessibilityLabel={item.text} accessibilityRole="tab">
+      <Pressable key={index} disabled={item.disabled} onPress={() => this.changeItem(item, index)} style={(state) => pressableFeedbackStyle(state, finalStyle)} accessibilityLabel={item.text} accessibilityRole="tab">
         <Text type={active ? 'heading-compact-01' : 'body-compact-01'} style={textStyle} breakMode="tail" text={item.text} />
       </Pressable>
     );

--- a/src/components/Tag/index.tsx
+++ b/src/components/Tag/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { GestureResponderEvent, ViewProps, StyleProp, StyleSheet, View, ViewStyle, Pressable } from 'react-native';
-import { createIcon, styleReferenceBreaker } from '../../helpers';
+import { createIcon, pressableFeedbackStyle, styleReferenceBreaker } from '../../helpers';
 import CloseIcon from '@carbon/icons/es/close/20';
 import { getColor } from '../../styles/colors';
 import { Text } from '../Text';
@@ -113,7 +113,7 @@ export class Tag extends React.Component<TagProps> {
 
     if (typeof onClosePress === 'function') {
       return (
-        <Pressable onPress={onClosePress} disabled={disabled} accessibilityLabel={title} accessibilityRole="button" style={this.styles.action}>
+        <Pressable onPress={onClosePress} disabled={disabled} accessibilityLabel={title} accessibilityRole="button" style={(state) => pressableFeedbackStyle(state, this.styles.action)}>
           {createIcon(CloseIcon, 16, 16, this.textColor)}
         </Pressable>
       );

--- a/src/components/Tile/index.tsx
+++ b/src/components/Tile/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ViewProps, StyleProp, StyleSheet, ViewStyle, ScrollView, View, GestureResponderEvent, Pressable } from 'react-native';
 import { getColor } from '../../styles/colors';
-import { styleReferenceBreaker } from '../../helpers';
+import { pressableFeedbackStyle, styleReferenceBreaker } from '../../helpers';
 import { defaultText } from '../../constants/defaultText';
 
 export type TileProps = {
@@ -50,7 +50,7 @@ export class Tile extends React.Component<TileProps> {
         );
       case 'clickable':
         return (
-          <Pressable onPress={onPress} onLongPress={onLongPress} accessibilityRole="button" accessibilityLabel={tileText || defaultText.tile} style={finalStyles} {...(componentProps || {})}>
+          <Pressable onPress={onPress} onLongPress={onLongPress} accessibilityRole="button" accessibilityLabel={tileText || defaultText.tile} style={(state) => pressableFeedbackStyle(state, finalStyles)} {...(componentProps || {})}>
             {children}
           </Pressable>
         );

--- a/src/components/TopNavigationBar/index.tsx
+++ b/src/components/TopNavigationBar/index.tsx
@@ -85,10 +85,12 @@ export class TopNavigationBar extends React.Component<TopNavigationBarProps> {
       },
       leftLink: {
         paddingTop: 13,
+        paddingBottom: 13,
         paddingLeft: 16,
       },
       rightLink: {
         paddingTop: 13,
+        paddingBottom: 13,
         paddingRight: 16,
         marginLeft: 'auto',
       },

--- a/src/components/WebHeader/index.tsx
+++ b/src/components/WebHeader/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Pressable, StyleProp, StyleSheet, View, ViewProps, ViewStyle } from 'react-native';
 import type { CarbonIcon } from '../../types/shared';
-import { createIcon, styleReferenceBreaker } from '../../helpers';
+import { createIcon, pressableFeedbackStyle, styleReferenceBreaker } from '../../helpers';
 import { getColor } from '../../styles/colors';
 import { Text } from '../Text';
 
@@ -95,7 +95,7 @@ export class WebHeader extends React.Component<WebHeaderProps> {
           actions.map((action, index) => {
             return (
               <View style={this.styles.actionWrapper} key={index}>
-                <Pressable style={this.styles.actionButton} onPress={action.onPress} accessibilityLabel={action.text} accessibilityRole="button">
+                <Pressable style={(state) => pressableFeedbackStyle(state, this.styles.actionButton)} onPress={action.onPress} accessibilityLabel={action.text} accessibilityRole="button">
                   <View style={this.styles.actionButtonImage}>{createIcon(action.icon, 20, 20, getColor('textOnColor', 'light'))}</View>
                 </Pressable>
               </View>

--- a/src/helpers/index.tsx
+++ b/src/helpers/index.tsx
@@ -3,6 +3,7 @@ import { toString } from '@carbon/icon-helpers';
 import { SvgXml } from 'react-native-svg';
 import { getColor } from '../styles/colors';
 import type { CarbonIcon } from '../types/shared';
+import type { PressableStateCallbackType, StyleProp, ViewStyle } from 'react-native';
 
 /**
  * Log issues in console or other system that happen during the use of the library
@@ -51,4 +52,25 @@ export const styleReferenceBreaker = (style: any, extraStyle?: any): any => {
   finalStyle = Object.assign(finalStyle, extraStyle || {});
 
   return finalStyle;
+};
+
+/**
+ * Pressable styling helper for adding proper feedback to the user
+ * Use on Pressable as `style={(state) => pressableFeedbackStyle(state, this.myStyle)}`
+ *
+ * @param state - State from the style function
+ * @param style - Primary style to add to the pressable
+ * @param customStyle - Function to use custom styling for state changes.  If using may not need this helper at all. But also not bad to have everything in one flow.
+ *
+ * @returns - Styled for handling press style
+ */
+export const pressableFeedbackStyle = (state: PressableStateCallbackType, style: StyleProp<ViewStyle>, customStyle: (state: PressableStateCallbackType) => StyleProp<ViewStyle>): StyleProp<ViewStyle> => {
+  return [
+    style,
+    typeof customStyle === 'function'
+      ? customStyle(state)
+      : {
+          opacity: state.pressed ? 0.8 : 1,
+        },
+  ];
 };


### PR DESCRIPTION
Closes #49
- Add prop to link for Back button style

Other
- Make nav link click area full size
- Migrate all icons to 20 (earlier in development some were 22 to follow a file that had Icons without padding (Carbon Icons sometimes have padding in the SVG). But that is causing more issue than solving. Migrate all back to 20.
- Add helper for Pressable to introduce some basic feedback. This will need to become more specific for some components. But at minimum all should have something.