### PR TITLE
fix(89, 94): login checkbox, row dividers and icon on DataTable

### DIFF
--- a/example/src/Views/DataTable.tsx
+++ b/example/src/Views/DataTable.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { StyleSheet, ScrollView, Alert } from 'react-native';
 import { DataTableCell, DataTableRow, DataTableHeader, DataTableHeaderProps, DataTable } from 'carbon-react-native';
-import ArrowRightIcon from '@carbon/icons/es/arrow--right/20';
+import AddIcon from '@carbon/icons/es/add/20';
 import SearchIcon from '@carbon/icons/es/search/20';
 import SettingsIcon from '@carbon/icons/es/settings/20';
 
@@ -27,7 +27,7 @@ export default class TestDataTable extends React.Component {
       primaryAction: {
         kind: 'primary',
         text: 'Primary button',
-        icon: ArrowRightIcon,
+        icon: AddIcon,
         onPress: () => this.alert('Pressed primary button'),
       },
       secondaryActions: [

--- a/src/components/BaseTextInputs/index.tsx
+++ b/src/components/BaseTextInputs/index.tsx
@@ -125,12 +125,12 @@ export const getTextInputStyle = (light?: boolean, hasLabelLink?: boolean, fullB
     labelWrapper: {
       flexDirection: 'row',
       flexWrap: 'wrap',
-      marginBottom: 8,
     },
     label: {
       color: getColor('textSecondary'),
       flex: 1,
       paddingTop: hasLabelLink ? 30 : undefined,
+      marginBottom: 8,
     },
     helperText: {
       color: getColor('textHelper'),

--- a/src/components/Checkbox/index.tsx
+++ b/src/components/Checkbox/index.tsx
@@ -50,6 +50,7 @@ export class Checkbox extends React.Component<CheckboxRadioProps> {
       checkboxWrapper: {
         flexDirection: 'row',
         flexWrap: 'wrap',
+        alignItems: 'center',
       },
     });
   }

--- a/src/components/DataTable/DataTableRow.tsx
+++ b/src/components/DataTable/DataTableRow.tsx
@@ -27,6 +27,8 @@ export class DataTableRow extends React.Component<DataTableRowProps> {
         height: 48,
         flexDirection: 'row',
         width: '100%',
+        borderTopColor: getColor('borderSubtle00'),
+        borderTopWidth: 1,
       },
     });
   }


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon-react-native/issues/94
Closes https://github.com/carbon-design-system/carbon-react-native/issues/89

<img width="1003" alt="Screenshot 2022-12-11 at 10 48 01 AM" src="https://github.com/carbon-design-system/carbon-react-native/assets/139924088/ccda3316-1b3f-49dd-8c6c-86e6bbb1b23a">
<img width="994" alt="Screenshot 2022-12-11 at 10 28 21 AM" src="https://github.com/carbon-design-system/carbon-react-native/assets/139924088/3f06df58-5fc7-4e33-ac38-c8e8b0a7536e">
