### PR TITLE
chore(setup): initial updates after migration

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,112 @@
+# Carbon Code of Conduct
+
+## TL;DR
+
+- **Be respectful & understanding.** Not all of us will agree all the time, but
+  disagreement is no excuse for poor behavior or poor manners. It is important
+  that we resolve disagreements and differing views constructively.
+
+* **Be welcoming.** We strive to be a community that welcomes and supports
+  people of all backgrounds and identities.
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and
+expression, level of experience, education, socio-economic status, nationality,
+personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Degrading, demeaning or disrespectful comments
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, or to ban temporarily or permanently any
+contributor for other behaviors that they deem inappropriate, threatening,
+offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, including _but not
+limited to_ GitHub, e-mail and Slack. It also applies when an individual is
+representing the project or its community in public spaces. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at carbon@us.ibm.com. All complaints
+will be reviewed and investigated and will result in a response that is deemed
+necessary and appropriate to the circumstances. The project team is obligated to
+maintain confidentiality with regard to the reporter of an incident. Further
+details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Slack
+
+1.  Please, no `@here` or `@channel` unless it is a bug that is **breaking
+    production code.** We have communities in many different time zones, and we
+    would hate to disrupt someone not at the office.
+2.  There's no need to notify the Carbon team that you have made an issue in
+    Carbon's GitHub repositories. We check these several times a day, so we
+    promise we'll address your issue as soon as we can.
+3.  Reserve direct messages for sensitive discussions, such as privacy, legal,
+    or HR reasons. Otherwise, we encourage posting in public channels so people
+    with the same questions can benefit.
+4.  If you have a pressing bug fix, it is best to make a PR directly to get your
+    issues addressed.
+5.  `#carbon-components`: This channel is for questions about Carbon Components
+    only. It is not the place to ask general coding questions. Instead, use a
+    dev community like [StackOverflow](https://stackoverflow.com/).
+6.  `#carbon-design-system`: Please post any design questions with an in-context
+    screen shot (i.e. screen shot of the whole UI you are designing) with
+    background as to what you are trying to accomplish in this flow. We welcome
+    in-progress work to get community design feedback as well.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org), version 1.4,
+available
+[here](https://www.contributor-covenant.org/version/1/4/code-of-conduct.html).
+For answers to common questions about this code of conduct, see the Contributor
+Covenant [FAQ](https://www.contributor-covenant.org/faq).
+
+<hr>
+
+If you have suggestions to improve this Code of Conduct, please submit an issue
+or PR.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'daily'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,94 @@
+name: ci
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  merge_group:
+    types: [checks_requested]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+      - name: Install dependencies
+        run: |
+          yarn install --cwd example --frozen-lockfile
+          yarn install --frozen-lockfile
+      - name: Lint JavaScript files
+        run: yarn lint
+
+  typescript:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+      - name: Install dependencies
+        run: |
+          yarn install --cwd example --frozen-lockfile
+          yarn install --frozen-lockfile
+      - name: Run typescript
+        run: yarn typescript
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+      - uses: actions/cache@v3
+        id: cache
+        with:
+          path: |
+            node_modules
+            */**/node_modules
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+      - name: Install dependencies
+        run: |
+          yarn install --cwd example --frozen-lockfile
+          yarn install --frozen-lockfile
+      - name: Run tests
+        run: yarn test --coverage
+      - name: Archive code coverage results
+        uses: actions/upload-artifact@v3
+        with:
+          name: code-coverage-report
+          path: coverage
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+      - uses: actions/cache@v3
+        id: cache
+        with:
+          path: |
+            node_modules
+            */**/node_modules
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+      - name: Install dependencies
+        run: |
+          yarn install --cwd example --frozen-lockfile
+          yarn install --frozen-lockfile
+      - name: Build package
+        run: yarn prepare

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,40 @@
+name: 'DCO Assistant'
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+  merge_group:
+    types: [checks_requested]
+
+jobs:
+  DCO:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'DCO Assistant'
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body
+          == 'I have read the DCO document and I hereby sign the DCO.') ||
+          github.event_name == 'pull_request_target'
+        uses: cla-assistant/github-action@5bfe123a0731f017d9c29550976bf724fe0870f5 #2.3.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.DCO_PERSONAL_ACCESS_TOKEN }}
+        with:
+          path-to-signatures: 'dco-signatures.json'
+          path-to-document: 'https://github.com/carbon-design-system/carbon-dco/blob/main/dco.md'
+          branch: 'main'
+          allowlist: bot*
+          remote-organization-name: carbon-design-system
+          remote-repository-name: carbon-dco
+          create-file-commit-message: 'chore: create file to store dco signatures'
+          signed-commit-message: 'chore: $contributorName has signed the dco in #$pullRequestNo'
+          custom-notsigned-prcomment:
+            'Thanks for your submission! We ask that $you sign our [Developer
+            Certificate of
+            Origin](https://github.com/carbon-design-system/carbon-dco/blob/main/dco.md)
+            before we can accept your contribution. You can sign the DCO by
+            adding a comment below using this text:'
+          custom-pr-sign-comment: 'I have read the DCO document and I hereby sign the DCO.'
+          custom-allsigned-prcomment: 'All contributors have signed the DCO.'
+          lock-pullrequest-aftermerge: false
+          use-dco-flag: true

--- a/README.md
+++ b/README.md
@@ -1,41 +1,43 @@
-# Carbon React Native Library
+# Carbon for React Native
+
 Component and shared patterns for React Native apps using Carbon. Styles are based on the [Carbon Native Mobile](https://carbondesignsystem.com/designing/design-resources/#native-mobile) designs. Color (g10 for light theme and g100 for dark theme) and typography tokens are based on Carbon 11.
 
 ## Installation
+
 1. Install the package in your project `npm install carbon-react-native` or `yarn add carbon-react-native`
 2. Go into the `ios` directory and use `pod install` (be sure to use the system Ruby on Mac if you are using rvm or similar tool)
 3. Create or edit `react-native.config.js` file to be:
-    ``` javascript
-    module.exports = {
-      project: {
-        ios: {},
-        android: {},
-      },
-      assets: [
-        './node_modules/carbon-react-native/src/assets/fonts/'  // This needs to be added if file already exists
-      ],
-    };
-    ```
+   ```javascript
+   module.exports = {
+     project: {
+       ios: {},
+       android: {},
+     },
+     assets: [
+       './node_modules/carbon-react-native/src/assets/fonts/', // This needs to be added if file already exists
+     ],
+   };
+   ```
 4. Run `npx react-native-asset` to link the fonts (install this package if not already).
-5. Install the following peer dependencies (install as dependencies.  [See dependecies here for tested versions](example/package.json)):
-    - @carbon/themes
-    - @carbon/icons
-    - @carbon/icon-helpers
-    - react-native-svg
-    - react-native-webview
+5. Install the following peer dependencies (install as dependencies. [See dependecies here for tested versions](example/package.json)):
+   - @carbon/themes
+   - @carbon/icons
+   - @carbon/icon-helpers
+   - react-native-svg
+   - react-native-webview
 
 ## Recommended Settings
 
-For best experience with navigation we recommend for Android setting `android:windowSoftInputMode="adjustPan"` in your AndroidManifest file. This will prevent the bottom navigation from pushing up.  Other known mechanisms exist and you should consider keyboard overlay for developing input areas.
+For best experience with navigation we recommend for Android setting `android:windowSoftInputMode="adjustPan"` in your AndroidManifest file. This will prevent the bottom navigation from pushing up. Other known mechanisms exist and you should consider keyboard overlay for developing input areas.
 
 ## Usage
 
 ### Components
 
 ```js
-import { Button } from "carbon-react-native";
+import { Button } from 'carbon-react-native';
 
-<Button kind="primary" text="My Button" onPress={() => {}} />
+<Button kind="primary" text="My Button" onPress={() => {}} />;
 ```
 
 ### Colors
@@ -43,7 +45,7 @@ import { Button } from "carbon-react-native";
 You can use `getColor` to retrieve a color token using the system theme for Carbon colors. You can pass a second param to force a theme (light/dark).
 
 ```js
-import { getColor } from "carbon-react-native";
+import { getColor } from 'carbon-react-native';
 
 const styles = StyleSheet.create({
   example: {
@@ -54,13 +56,13 @@ const styles = StyleSheet.create({
 });
 ```
 
-Color scheme will follow the OS. You can request specific colors at any point via second param on get Color. If you wish to use a theme for your app you will need to set the theme globally. This means that any color you use in your own styling will need to be done via a getter (and have this component reload its state). For changing your own colors on the fly you need to ensure getters are used for those styles using color.  You can use the `forceTheme` function to change the theme and trigger a state update to change the color.
+Color scheme will follow the OS. You can request specific colors at any point via second param on get Color. If you wish to use a theme for your app you will need to set the theme globally. This means that any color you use in your own styling will need to be done via a getter (and have this component reload its state). For changing your own colors on the fly you need to ensure getters are used for those styles using color. You can use the `forceTheme` function to change the theme and trigger a state update to change the color.
 
 ### Icons
 
-You can use icons from `@carbon/icons` to pass to components.  We do not bundle all icons in this library to reduce size. You can import specific icons from that library directly as needed.  An example of how to pass icons to the React Native components is below.
+You can use icons from `@carbon/icons` to pass to components. We do not bundle all icons in this library to reduce size. You can import specific icons from that library directly as needed. An example of how to pass icons to the React Native components is below.
 
-``` javascript
+```javascript
 import AddIcon from '@carbon/icons/es/add/20';
 
 // Using an icon with a component that supports Carbon Icons.

--- a/example/package.json
+++ b/example/package.json
@@ -10,6 +10,7 @@
     "pods": "pod-install --quiet",
     "postinstall": "patch-package"
   },
+  "license": "Apache-2.0",
   "dependencies": {
     "@carbon/icon-helpers": "^10.42.1",
     "@carbon/icons": "^11.22.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "carbon-react-native",
+  "name": "@carbon/react-native",
   "version": "0.3.4",
   "description": "Carbon React Native Library",
   "main": "lib/commonjs/index",


### PR DESCRIPTION
* Add the code of conduct from the Carbon monorepo
* Add the dependabot config file
* Add a new ci.yml workflow for GitHub Action's based ci
  * I just took a rough jab at this, it might need refined or fixed. I just copied over what seemed applicable from the circleci config.yml
  * The status checks from it are not required in any way, so we should be able to easily test and debug things as necessary before making them required
* Added the Developer Certificate of Origin workflow (also added the required secrets to this repo settings)
* Minor update to the readme (also caused an unintentional formatting change, prettier maybe?)
* Add license to example directory package.json
* Renamed project to `@carbon/react-native` for when we eventually set up npm publishing to that scope