### PR TITLE
feat(#145): custom theming for Colors and Font family

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
   </a>
   <a href="https://bestpractices.coreinfrastructure.org/projects/7741">
     <img src="https://bestpractices.coreinfrastructure.org/projects/7741/badge">
-  </a> 
+  </a>
   <a href="https://discord.gg/J7JEUEkTRX">
     <img src="https://img.shields.io/discord/689212587170201628?color=5865F2" alt="Chat with us on Discord">
   </a>
@@ -111,6 +111,18 @@ import AddIcon from '@carbon/icons/es/add/20';
 // Using an icon directly in your own component. You can use our helper.  See `createIcon` params for options.
 <View>{createIcon(icon, 20, 20)}</View>
 ```
+
+### Overriding Themes
+
+You can override the default Carbon theme (Carbon Colors and IBM Plex) by using the built in theme override calls. These should be done first in your app during a loading state or initial load. If done after app load any component already rendered needs to redraw state.
+
+#### Overriding colors
+
+Colors can be overridden by using `overrideLightTheme` or `overrideDarkTheme`. If you wish to use only one theme for your app you can simply `forceTheme` as well to lock the app to a single theme. Colors are written in camelCase and follow the tokens found at [Carbon Design Systems](https://carbondesignsystem.com/guidelines/color/tokens).
+
+#### Overriding fonts
+
+Fonts can be overridden on individual components by overriding the style (`fontFamily`, `fontWeight`). However, you can also override them globally. By calling `overrideFonts` which takes in a family and weight for each of the internal font groups components use. If you use a font be sure to use one that is supported on the OS you are running. Android and iOS have different supported fonts. You can also use custom fonts as long as you bundle them as part of your app.  It is a similar process to how we add Plex above in the "Getting started" section.
 
 ## Contributing
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -59,6 +59,7 @@ import TestLoginForgotPassword from './Views/LoginForgotPassword';
 import TestLoginCreatePassword from './Views/LoginCreatePassword';
 import TestLoginCreateAccount from './Views/LoginCreateAccount';
 import TestFormItem from './Views/FormItem';
+import TestOverrideTheme from './Views/OverrideTheme';
 
 export type ComponentItem = {
   component: React.ReactNode;
@@ -101,6 +102,13 @@ export default class App extends React.Component {
 
   private clearView = (): void => {
     this.setState({ view: '' });
+  };
+
+  private reloadView = (): void => {
+    this.setState({ loading: true });
+    setTimeout(() => {
+      this.setState({ loading: false });
+    }, 100);
   };
 
   private componentViewList: [string, ComponentItem][] = [
@@ -147,6 +155,7 @@ export default class App extends React.Component {
     ['Top navigation bar login', { component: <TestTopNavigationBarLogin />, imageLight: null, imageDark: null }],
     ['Slider', { component: <TestSlider />, imageLight: null, imageDark: null }],
     ['Form item', { component: <TestFormItem />, imageLight: null, imageDark: null }],
+    ['Theme override', { component: <TestOverrideTheme reloadView={this.reloadView} />, imageLight: null, imageDark: null }],
   ];
 
   private flowViewList: [string, ComponentItem][] = [

--- a/example/src/Views/OverrideTheme.tsx
+++ b/example/src/Views/OverrideTheme.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import * as g10 from '@carbon/themes/src/g10.js';
+import { StyleSheet, ScrollView, Platform } from 'react-native';
+import { Text, Button, overrideDarkTheme, overrideLightTheme, ThemeDefinition, componentsG10, overrideFonts, FontWeights, RegularFont } from '@carbon/react-native';
+
+const styles = StyleSheet.create({
+  view: {
+    flex: 1,
+  },
+  container: {
+    flexGrow: 1,
+  },
+  baseSpacing: {
+    marginTop: 20,
+    fontFamily: '',
+  },
+});
+
+export default class TestOverrideTheme extends React.Component<{ reloadView: () => void }> {
+  private randomTheme = (): void => {
+    const { reloadView } = this.props;
+
+    const newTheme: ThemeDefinition = {};
+    const componentKeys = [...Object.keys(componentsG10), ...Object.keys(g10)];
+
+    componentKeys.forEach((key) => {
+      const testString = Math.floor(Math.random() * 16777215).toString(16);
+      newTheme[key] = `#${testString.length === 6 ? testString : '123abc'}`;
+    });
+
+    overrideDarkTheme(newTheme);
+    overrideLightTheme(newTheme);
+
+    reloadView();
+  };
+
+  private get fontList(): string[] {
+    const iosList = ['Times New Roman', 'Papyrus', 'Menlo', 'Helvetica', 'Chalkboard S', 'San Francisco'];
+    const androidList = ['normal', 'notoserif', 'sans-serif', 'Roboto', 'monospace', 'sans-serif-condensed'];
+
+    return Platform.OS === 'ios' ? iosList : androidList;
+  }
+
+  private randomFont = (): void => {
+    const { reloadView } = this.props;
+
+    const fontFamily = this.fontList[Math.floor(Math.random() * (this.fontList.length - 1))];
+
+    if (fontFamily) {
+      overrideFonts({
+        light: {
+          fontWeight: '300' as FontWeights,
+          fontFamily,
+        },
+        regular: {
+          fontWeight: '400' as FontWeights,
+          fontFamily,
+        },
+        semiBold: {
+          fontWeight: '600' as FontWeights,
+          fontFamily,
+        },
+        monoRegular: {
+          fontWeight: '400' as FontWeights,
+          fontFamily,
+        },
+      });
+
+      reloadView();
+    }
+  };
+
+  private resetTheme = (): void => {
+    const { reloadView } = this.props;
+
+    overrideDarkTheme({});
+    overrideLightTheme({});
+    overrideFonts({});
+
+    reloadView();
+  };
+
+  render(): React.ReactNode {
+    return (
+      <ScrollView keyboardShouldPersistTaps="handled" contentInsetAdjustmentBehavior="automatic" contentContainerStyle={styles.container} style={styles.view}>
+        <Text style={styles.baseSpacing} text="Override theme using options below. Theme will be set to this until you kill the app or reset." />
+        <Button style={styles.baseSpacing} text="Set random color theme" onPress={this.randomTheme} />
+        <Button style={styles.baseSpacing} text="Set random font" onPress={this.randomFont} />
+        <Text style={styles.baseSpacing} text={`Current font: ${RegularFont().fontFamily}`} />
+        <Button style={styles.baseSpacing} text="Reset theme" onPress={this.resetTheme} />
+      </ScrollView>
+    );
+  }
+}

--- a/src/components/BaseTextInputs/index.tsx
+++ b/src/components/BaseTextInputs/index.tsx
@@ -86,7 +86,7 @@ export type TextInputProps = {
 export const getTextInputStyle = (light?: boolean, hasLabelLink?: boolean, fullBleed?: boolean) => {
   // React Native on iOS
   const baseTextBox: any = {
-    ...BodyCompact02,
+    ...BodyCompact02(),
     height: 48,
     backgroundColor: getColor('field01'),
     borderColor: getColor('field01'),
@@ -372,7 +372,7 @@ export class BaseTextInput extends React.Component<BaseTextInputProps & TextInpu
       textBoxStyle.height = textAreaMinHeight || 144;
       textBoxStyle.paddingTop = 12;
       textBoxStyle.paddingBottom = 12;
-      textBoxStyle = styleReferenceBreaker(textBoxStyle, Body02);
+      textBoxStyle = styleReferenceBreaker(textBoxStyle, Body02());
     } else if (password || date) {
       textBoxStyle.paddingRight = 50;
     } else if (number) {

--- a/src/components/BottomNavigationBar/index.tsx
+++ b/src/components/BottomNavigationBar/index.tsx
@@ -4,7 +4,7 @@ import { getColor } from '../../styles/colors';
 import { createIcon, pressableFeedbackStyle, styleReferenceBreaker } from '../../helpers';
 import type { NavigationButton } from '../../types/navigation';
 import { Text } from '../Text';
-import { SemiBoldPlex } from '../../styles/typography';
+import { SemiBoldFont } from '../../styles/typography';
 
 export type BottomNavigationBarProps = {
   /** Navigation items to load */
@@ -41,7 +41,7 @@ export class BottomNavigationBar extends React.Component<BottomNavigationBarProp
         marginLeft: 'auto',
       },
       textActive: {
-        ...SemiBoldPlex,
+        ...SemiBoldFont(),
       },
     });
   }

--- a/src/components/LandingView/index.tsx
+++ b/src/components/LandingView/index.tsx
@@ -7,7 +7,7 @@ import { Text } from '../Text';
 import { Link } from '../Link';
 import { styleReferenceBreaker } from '../../helpers';
 import { ViewWrapper } from '../ViewWrapper';
-import { SemiBoldPlex } from '../../styles/typography';
+import { SemiBoldFont } from '../../styles/typography';
 
 export type LandingViewProps = {
   /** Company image to load in top right. Can pass in many ways including require `require('../../assets/images/image.png')` */
@@ -83,7 +83,7 @@ export class LandingView extends React.Component<LandingViewProps> {
       },
       title: {
         marginBottom: 16,
-        ...SemiBoldPlex,
+        ...SemiBoldFont(),
       },
       helperContent: {},
       contentWrapper: {

--- a/src/components/Text/index.tsx
+++ b/src/components/Text/index.tsx
@@ -27,68 +27,68 @@ export class Text extends React.Component<TextProps> {
 
     switch (type) {
       case 'code-01':
-        finalStyle = styleReferenceBreaker(Code01);
+        finalStyle = styleReferenceBreaker(Code01());
         break;
       case 'code-02':
-        finalStyle = styleReferenceBreaker(Code02);
+        finalStyle = styleReferenceBreaker(Code02());
         break;
       case 'label-01':
-        finalStyle = styleReferenceBreaker(Label01);
+        finalStyle = styleReferenceBreaker(Label01());
         break;
       case 'label-02':
-        finalStyle = styleReferenceBreaker(Label02);
+        finalStyle = styleReferenceBreaker(Label02());
         break;
       case 'helper-text-01':
-        finalStyle = styleReferenceBreaker(HelperText01);
+        finalStyle = styleReferenceBreaker(HelperText01());
         break;
       case 'helper-text-02':
-        finalStyle = styleReferenceBreaker(HelperText02);
+        finalStyle = styleReferenceBreaker(HelperText02());
         break;
       case 'legal-01':
-        finalStyle = styleReferenceBreaker(Legal01);
+        finalStyle = styleReferenceBreaker(Legal01());
         break;
       case 'legal-02':
-        finalStyle = styleReferenceBreaker(Legal02);
+        finalStyle = styleReferenceBreaker(Legal02());
         break;
       case 'body-compact-01':
-        finalStyle = styleReferenceBreaker(BodyCompact01);
+        finalStyle = styleReferenceBreaker(BodyCompact01());
         break;
       case 'body-01':
-        finalStyle = styleReferenceBreaker(Body01);
+        finalStyle = styleReferenceBreaker(Body01());
         break;
       case 'body-02':
-        finalStyle = styleReferenceBreaker(Body02);
+        finalStyle = styleReferenceBreaker(Body02());
         break;
       case 'heading-compact-01':
-        finalStyle = styleReferenceBreaker(HeadingCompact01);
+        finalStyle = styleReferenceBreaker(HeadingCompact01());
         break;
       case 'heading-compact-02':
-        finalStyle = styleReferenceBreaker(HeadingCompact02);
+        finalStyle = styleReferenceBreaker(HeadingCompact02());
         break;
       case 'heading-01':
-        finalStyle = styleReferenceBreaker(Heading01);
+        finalStyle = styleReferenceBreaker(Heading01());
         break;
       case 'heading-02':
-        finalStyle = styleReferenceBreaker(Heading02);
+        finalStyle = styleReferenceBreaker(Heading02());
         break;
       case 'heading-03':
-        finalStyle = styleReferenceBreaker(Heading03);
+        finalStyle = styleReferenceBreaker(Heading03());
         break;
       case 'heading-04':
-        finalStyle = styleReferenceBreaker(Heading04);
+        finalStyle = styleReferenceBreaker(Heading04());
         break;
       case 'heading-05':
-        finalStyle = styleReferenceBreaker(Heading05);
+        finalStyle = styleReferenceBreaker(Heading05());
         break;
       case 'heading-06':
-        finalStyle = styleReferenceBreaker(Heading06);
+        finalStyle = styleReferenceBreaker(Heading06());
         break;
       case 'heading-07':
-        finalStyle = styleReferenceBreaker(Heading07);
+        finalStyle = styleReferenceBreaker(Heading07());
         break;
       case 'body-compact-02':
       default:
-        finalStyle = styleReferenceBreaker(BodyCompact02);
+        finalStyle = styleReferenceBreaker(BodyCompact02());
         break;
     }
 

--- a/src/components/TopNavigationBar/index.tsx
+++ b/src/components/TopNavigationBar/index.tsx
@@ -6,7 +6,7 @@ import type { NavigationButton } from '../../types/navigation';
 import { Button } from '../Button';
 import { Link, LinkProps } from '../Link';
 import { Text } from '../Text';
-import { RegularPlex } from '../../styles/typography';
+import { RegularFont } from '../../styles/typography';
 
 export const headerBarGetItems = (items: NavigationButton[], style: unknown, itemStyle: unknown, type: 'right' | 'left', forceDarkMode?: boolean): React.ReactNode => {
   const finalWrapperStyles = styleReferenceBreaker(style);
@@ -109,7 +109,7 @@ export class TopNavigationBar extends React.Component<TopNavigationBarProps> {
         marginBottom: 8,
       },
       pageHeaderTitle: {
-        ...RegularPlex,
+        ...RegularFont(),
       },
       pageHeaderSubTitle: {
         color: getColor('textSecondary'),

--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -5,13 +5,16 @@ import { logIssue } from '../helpers';
 
 /** Theme choices available */
 export type ThemeChoices = 'light' | 'dark';
+export type ThemeDefinition = { [key: string]: string };
 
 let themeOverride: ThemeChoices | null = null;
+let lightThemeOverride: ThemeDefinition = {};
+let darkThemeOverride: ThemeDefinition = {};
 
 /**
  * Set the theme to use for all subsequent calls to the color getter.
  * To change themes on the fly you must have your style declarations retrieved on loads.
- * So you can destroy the view and reload after changing theem.
+ * So you can destroy the view and reload after changing theme.
  *
  * To lock a theme (no auto themes) call this in your entry point (index or App [before any components])
  *
@@ -19,6 +22,34 @@ let themeOverride: ThemeChoices | null = null;
  */
 export const forceTheme = (theme: ThemeChoices | null): void => {
   themeOverride = theme;
+};
+
+/**
+ * Override the Carbon color theme for light mode with your own color set. Theme tokens are camelCase.
+ * See https://carbondesignsystem.com for tokens.
+ * Not all tokens will be used and you can customize the ones you care about.
+ * To use only this theme use forceTheme to the same theme you are overriding.
+ *
+ * @param themeDefinition - Partial or full set of theme tokens to override.
+ */
+export const overrideLightTheme = (themeDefinition: ThemeDefinition): void => {
+  if (themeDefinition && typeof themeDefinition === 'object') {
+    lightThemeOverride = themeDefinition;
+  }
+};
+
+/**
+ * Override the Carbon color theme for dark mode with your own color set. Theme tokens are camelCase.
+ * See https://carbondesignsystem.com for tokens.
+ * Not all tokens will be used and you can customize the ones you care about.
+ * To use only this theme use forceTheme to the same theme you are overriding.
+ *
+ * @param themeDefinition - Partial or full set of theme tokens to override.
+ */
+export const overrideDarkTheme = (themeDefinition: ThemeDefinition): void => {
+  if (themeDefinition && typeof themeDefinition === 'object') {
+    lightThemeOverride = themeDefinition;
+  }
 };
 
 /**
@@ -34,7 +65,7 @@ export const useDarkMode = (): boolean => {
 };
 
 /** Component colors are not part of themes and are in the main library; which is quite large. So hardcoding for now */
-const componentsG10: { [key: string]: string } = {
+export const componentsG10: { [key: string]: string } = {
   buttonPrimary: '#0f62fe',
   buttonPrimaryHover: '#0353e9',
   buttonPrimaryActive: '#002d9c',
@@ -87,7 +118,7 @@ const componentsG10: { [key: string]: string } = {
 };
 
 /** Component colors are not part of themes and are in the main library; which is quite large. So hardcoding for now */
-const componentsG100: { [key: string]: string } = {
+export const componentsG100: { [key: string]: string } = {
   buttonPrimary: '#0f62fe',
   buttonPrimaryHover: '#0353e9',
   buttonPrimaryActive: '#002d9c',
@@ -147,8 +178,8 @@ const componentsG100: { [key: string]: string } = {
  * @param overrideTheme - force return of specific theme color (will ignore system)
  */
 export const getColor = (token: string, overrideTheme?: ThemeChoices): string => {
-  let foundLightColor = g10[token] || componentsG10[token];
-  let foundDarkColor = g100[token] || componentsG100[token];
+  let foundLightColor = lightThemeOverride[token] || g10[token] || componentsG10[token];
+  let foundDarkColor = darkThemeOverride[token] || g100[token] || componentsG100[token];
 
   if (!foundLightColor) {
     logIssue('getColor: could not find requested color in light theme.', {

--- a/src/styles/typography.ts
+++ b/src/styles/typography.ts
@@ -5,196 +5,281 @@
  * If you want to use other fonts you can download them and store them in your app and follow same directions on README.
  */
 
-type FontWeights = 'normal' | 'bold' | '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900' | undefined;
+export type FontWeights = 'normal' | 'bold' | '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900' | undefined;
 
-/** Plex light styling */
-export const LightPlex = {
-  fontWeight: '300' as FontWeights,
-  fontFamily: 'IBMPlexSans-Light',
+export type FontDefinition = {
+  fontWeight: FontWeights;
+  fontFamily: string;
 };
 
-/** Plex regular styling */
-export const RegularPlex = {
-  fontWeight: '400' as FontWeights,
-  fontFamily: 'IBMPlexSans-Regular',
+export type FontDefinitionOverrides = {
+  light?: FontDefinition;
+  regular?: FontDefinition;
+  semiBold?: FontDefinition;
+  monoRegular?: FontDefinition;
 };
 
-/** Plex semi-bold styling */
-export const SemiBoldPlex = {
-  fontWeight: '600' as FontWeights,
-  fontFamily: 'IBMPlexSans-SemiBold',
+let overrideFontDefinition: FontDefinitionOverrides = {};
+
+/**
+ * Override internal font groups. By default Carbon uses Plex.
+ * You can override with your own font family here. You can choose to only override some or all.
+ * You must install the fonts and setup React Native to bundle your custom font family if not using an available system font.
+ *
+ * @param overrides - The font sets the app use internally
+ */
+export const overrideFonts = (overrides: FontDefinitionOverrides): void => {
+  if (overrides && typeof overrides === 'object') {
+    overrideFontDefinition = overrides;
+  }
 };
 
-/** Plex Mono regular styling */
-export const MonoRegularPlex = {
-  fontWeight: '400' as FontWeights,
-  fontFamily: 'IBMPlexMono',
+/** Font light styling */
+export const LightFont = (): FontDefinition => {
+  return (
+    overrideFontDefinition.light || {
+      fontWeight: '300' as FontWeights,
+      fontFamily: 'IBMPlexSans-Light',
+    }
+  );
+};
+
+/** Font regular styling */
+export const RegularFont = (): FontDefinition => {
+  return (
+    overrideFontDefinition.regular || {
+      fontWeight: '400' as FontWeights,
+      fontFamily: 'IBMPlexSans-Regular',
+    }
+  );
+};
+
+/** Font semi-bold styling */
+export const SemiBoldFont = (): FontDefinition => {
+  return (
+    overrideFontDefinition.semiBold || {
+      fontWeight: '600' as FontWeights,
+      fontFamily: 'IBMPlexSans-SemiBold',
+    }
+  );
+};
+
+/** Font Mono regular styling */
+export const MonoRegularFont = (): FontDefinition => {
+  return (
+    overrideFontDefinition.monoRegular || {
+      fontWeight: '400' as FontWeights,
+      fontFamily: 'IBMPlexMono',
+    }
+  );
 };
 
 /** Code-01 text style (Productive) */
-export const Code01 = {
-  fontSize: 12,
-  lineHeight: 16,
-  letterSpacing: 0.32,
-  ...MonoRegularPlex,
+export const Code01 = () => {
+  return {
+    fontSize: 12,
+    lineHeight: 16,
+    letterSpacing: 0.32,
+    ...MonoRegularFont(),
+  };
 };
 
 /** Code-02 text style (Expressive) */
-export const Code02 = {
-  fontSize: 14,
-  lineHeight: 20,
-  letterSpacing: 0.32,
-  ...MonoRegularPlex,
+export const Code02 = () => {
+  return {
+    fontSize: 14,
+    lineHeight: 20,
+    letterSpacing: 0.32,
+    ...MonoRegularFont(),
+  };
 };
 
 /** Label-01 text style (Productive) */
-export const Label01 = {
-  fontSize: 12,
-  lineHeight: 16,
-  letterSpacing: 0.32,
-  ...RegularPlex,
+export const Label01 = () => {
+  return {
+    fontSize: 12,
+    lineHeight: 16,
+    letterSpacing: 0.32,
+    ...RegularFont(),
+  };
 };
 
 /** Label-02 text style (Expressive) */
-export const Label02 = {
-  fontSize: 14,
-  lineHeight: 18,
-  letterSpacing: 0.16,
-  ...RegularPlex,
+export const Label02 = () => {
+  return {
+    fontSize: 14,
+    lineHeight: 18,
+    letterSpacing: 0.16,
+    ...RegularFont(),
+  };
 };
 
 /** Helper-text-01 text style (Productive) */
-export const HelperText01 = {
-  fontSize: 12,
-  lineHeight: 16,
-  letterSpacing: 0.32,
-  ...RegularPlex,
+export const HelperText01 = () => {
+  return {
+    fontSize: 12,
+    lineHeight: 16,
+    letterSpacing: 0.32,
+    ...RegularFont(),
+  };
 };
 
 /** Helper-text-02 text style (Expressive) */
-export const HelperText02 = {
-  fontSize: 14,
-  lineHeight: 18,
-  letterSpacing: 0.16,
-  ...RegularPlex,
+export const HelperText02 = () => {
+  return {
+    fontSize: 14,
+    lineHeight: 18,
+    letterSpacing: 0.16,
+    ...RegularFont(),
+  };
 };
 
 /** Legal-01 text style (Productive) */
-export const Legal01 = {
-  fontSize: 12,
-  lineHeight: 16,
-  letterSpacing: 0.32,
-  ...RegularPlex,
+export const Legal01 = () => {
+  return {
+    fontSize: 12,
+    lineHeight: 16,
+    letterSpacing: 0.32,
+    ...RegularFont(),
+  };
 };
 
 /** Legal-02 text style (Expressive) */
-export const Legal02 = {
-  fontSize: 14,
-  lineHeight: 18,
-  letterSpacing: 0.16,
-  ...RegularPlex,
+export const Legal02 = () => {
+  return {
+    fontSize: 14,
+    lineHeight: 18,
+    letterSpacing: 0.16,
+    ...RegularFont(),
+  };
 };
 
 /** Body-compact-01 text style (Productive) */
-export const BodyCompact01 = {
-  fontSize: 14,
-  lineHeight: 18,
-  letterSpacing: 0.16,
-  ...RegularPlex,
+export const BodyCompact01 = () => {
+  return {
+    fontSize: 14,
+    lineHeight: 18,
+    letterSpacing: 0.16,
+    ...RegularFont(),
+  };
 };
 
 /** Body-compact-02 text style (Expressive) */
-export const BodyCompact02 = {
-  fontSize: 16,
-  lineHeight: 22,
-  letterSpacing: 0,
-  ...RegularPlex,
+export const BodyCompact02 = () => {
+  return {
+    fontSize: 16,
+    lineHeight: 22,
+    letterSpacing: 0,
+    ...RegularFont(),
+  };
 };
 
 /** Body-01 text style (Productive) */
-export const Body01 = {
-  fontSize: 14,
-  lineHeight: 20,
-  letterSpacing: 0.16,
-  ...RegularPlex,
+export const Body01 = () => {
+  return {
+    fontSize: 14,
+    lineHeight: 20,
+    letterSpacing: 0.16,
+    ...RegularFont(),
+  };
 };
 
 /** Body-02 text style (Expressive) */
-export const Body02 = {
-  fontSize: 16,
-  lineHeight: 24,
-  letterSpacing: 0,
-  ...RegularPlex,
+export const Body02 = () => {
+  return {
+    fontSize: 16,
+    lineHeight: 24,
+    letterSpacing: 0,
+    ...RegularFont(),
+  };
 };
 
 /** Heading-compact-01 text style (Productive) */
-export const HeadingCompact01 = {
-  fontSize: 14,
-  lineHeight: 18,
-  letterSpacing: 0.16,
-  ...SemiBoldPlex,
+export const HeadingCompact01 = () => {
+  return {
+    fontSize: 14,
+    lineHeight: 18,
+    letterSpacing: 0.16,
+    ...SemiBoldFont(),
+  };
 };
 
 /** Heading-compact-02 text style (Expressive) */
-export const HeadingCompact02 = {
-  fontSize: 16,
-  lineHeight: 22,
-  letterSpacing: 0,
-  ...SemiBoldPlex,
+export const HeadingCompact02 = () => {
+  return {
+    fontSize: 16,
+    lineHeight: 22,
+    letterSpacing: 0,
+    ...SemiBoldFont(),
+  };
 };
 
 /** Heading-01 text style (Productive) */
-export const Heading01 = {
-  fontSize: 14,
-  lineHeight: 20,
-  letterSpacing: 0.16,
-  ...SemiBoldPlex,
+export const Heading01 = () => {
+  return {
+    fontSize: 14,
+    lineHeight: 20,
+    letterSpacing: 0.16,
+    ...SemiBoldFont(),
+  };
 };
 
 /** Heading-02 text style (Expressive) */
-export const Heading02 = {
-  fontSize: 16,
-  lineHeight: 24,
-  letterSpacing: 0,
-  ...SemiBoldPlex,
+export const Heading02 = () => {
+  return {
+    fontSize: 16,
+    lineHeight: 24,
+    letterSpacing: 0,
+    ...SemiBoldFont(),
+  };
 };
 
 /** Heading-03 text style (Productive) */
-export const Heading03 = {
-  fontSize: 20,
-  lineHeight: 28,
-  letterSpacing: 0,
-  ...RegularPlex,
+export const Heading03 = () => {
+  return {
+    fontSize: 20,
+    lineHeight: 28,
+    letterSpacing: 0,
+    ...RegularFont(),
+  };
 };
 
 /** Heading-04 text style (Productive) */
-export const Heading04 = {
-  fontSize: 28,
-  lineHeight: 36,
-  letterSpacing: 0,
-  ...RegularPlex,
+export const Heading04 = () => {
+  return {
+    fontSize: 28,
+    lineHeight: 36,
+    letterSpacing: 0,
+    ...RegularFont(),
+  };
 };
 
 /** Heading-05 text style (Productive) */
-export const Heading05 = {
-  fontSize: 32,
-  lineHeight: 40,
-  letterSpacing: 0,
-  ...LightPlex,
+export const Heading05 = () => {
+  return {
+    fontSize: 32,
+    lineHeight: 40,
+    letterSpacing: 0,
+    ...LightFont(),
+  };
 };
 
 /** Heading-06 text style (Productive) */
-export const Heading06 = {
-  fontSize: 42,
-  lineHeight: 50,
-  letterSpacing: 0,
-  ...LightPlex,
+export const Heading06 = () => {
+  return {
+    fontSize: 42,
+    lineHeight: 50,
+    letterSpacing: 0,
+    ...LightFont(),
+  };
 };
 
 /** Heading-07 text style (Productive) */
-export const Heading07 = {
-  fontSize: 54,
-  lineHeight: 64,
-  letterSpacing: 0,
-  ...LightPlex,
+export const Heading07 = () => {
+  return {
+    fontSize: 54,
+    lineHeight: 64,
+    letterSpacing: 0,
+    ...LightFont(),
+  };
 };


### PR DESCRIPTION
BREAKING CHANGE: if you are using typography exports they are now functions to faciliate overriding

Closes #145 

Changes:
- New font override function
- New color override function (dark mode)
- new color override function (light mode)
- Added example app view for seeing the changes in action

Example:
![Untitled4](https://github.com/carbon-design-system/carbon-react-native/assets/8028956/130e091f-4c28-47c1-8a55-b0b2f843b6e0)

