### PR TITLE
fix(#138): add carbon telemetry package

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "release": "release-it",
     "example": "yarn --cwd example",
     "bootstrap": "yarn example && yarn && yarn example pods",
-    "example:bump": "node ./scripts/bump-example.js"
+    "example:bump": "node ./scripts/bump-example.js",
+    "postinstall": "carbon-telemetry collect --install"
   },
   "keywords": [
     "ibm",
@@ -165,5 +166,8 @@
         }
       ]
     ]
+  },
+  "dependencies": {
+    "@carbon/telemetry": "^0.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1222,6 +1222,11 @@
   resolved "https://registry.npmjs.org/@carbon/layout/-/layout-11.16.1.tgz"
   integrity sha512-uUJmNrB7GKJzR/ZEzVxqGNb7US8UB1jL0X3lia3pnyqQ8Rcxq3y1RNmj/bfuI6LWC9GA0lLrsKRdKOpdLyqJMQ==
 
+"@carbon/telemetry@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@carbon/telemetry/-/telemetry-0.1.0.tgz#57b331cd5a855b4abbf55457456da8211624d879"
+  integrity sha512-kNWt0bkgPwGW0i5h7HFuljbKRXPvIhsKbB+1tEURAYLXoJg9iJLF1eGvWN5iVoFCS2zje4GR3OGOsvvKVe7Hlg==
+
 "@carbon/themes@^11.21.1":
   version "11.21.1"
   resolved "https://registry.npmjs.org/@carbon/themes/-/themes-11.21.1.tgz"


### PR DESCRIPTION
Closes #138 

Changes:
- Add as carbon telemetry as a depenency
- Add the requested call to post install script 