### PR TITLE
fix: bugs from Carbon migration from GHE

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - boost (1.76.0)
-  - carbon-react-native (1.0.0):
+  - carbon-react-native (6.0.0):
     - React-Core
   - CocoaAsyncSocket (7.6.5)
   - DoubleConversion (1.1.6)
@@ -674,7 +674,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
-  carbon-react-native: 5b61fba297337e90af0bea05b2bf11dc78971647
+  carbon-react-native: b66424b9c34711ac58fedc9d81b5595dbf0dff5a
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: 55cd4593d570bd9e5e227488d637ce6a9581ce51

--- a/example/src/Views/ActionSheet.tsx
+++ b/example/src/Views/ActionSheet.tsx
@@ -25,6 +25,8 @@ export default class TestActionSheet extends React.Component {
     lotItems: false,
     dangerItem: false,
     imageSupport: false,
+    showDivider: false,
+    fullBleed: false,
   };
 
   private openActionSheeet = (): void => {
@@ -32,7 +34,7 @@ export default class TestActionSheet extends React.Component {
   };
 
   private get items(): ActionSheetItem[] {
-    const { dangerItem, imageSupport } = this.state;
+    const { dangerItem, imageSupport, showDivider } = this.state;
 
     return [
       {
@@ -40,6 +42,7 @@ export default class TestActionSheet extends React.Component {
         onPress: () => {
           this.setState({ open: false });
         },
+        divider: showDivider,
       },
       {
         text: 'Item 1',
@@ -48,6 +51,7 @@ export default class TestActionSheet extends React.Component {
           this.setState({ open: false });
         },
         icon: imageSupport ? { image: require('../assets/react.png') } : undefined,
+        divider: showDivider,
       },
       {
         text: 'Item 2 wtih really long name that may be too long for many views',
@@ -56,6 +60,7 @@ export default class TestActionSheet extends React.Component {
           this.setState({ open: false });
         },
         icon: imageSupport ? { icon: PhoneIcon } : undefined,
+        divider: showDivider,
       },
       {
         text: 'Item 3 that is hidden',
@@ -64,6 +69,7 @@ export default class TestActionSheet extends React.Component {
           Alert.alert('Pressed item 3 on action sheet');
           this.setState({ open: false });
         },
+        divider: showDivider,
       },
       {
         text: 'Item 4',
@@ -73,12 +79,13 @@ export default class TestActionSheet extends React.Component {
           this.setState({ open: false });
         },
         icon: imageSupport ? { icon: PhoneIcon } : undefined,
+        divider: showDivider,
       },
     ];
   }
 
   render(): React.ReactNode {
-    const { open, showBody, forceCustom, lotItems, dangerItem, imageSupport } = this.state;
+    const { open, showBody, forceCustom, lotItems, dangerItem, imageSupport, showDivider, fullBleed } = this.state;
 
     return (
       <ScrollView keyboardShouldPersistTaps="handled" contentInsetAdjustmentBehavior="automatic" contentContainerStyle={styles.container} style={styles.view}>
@@ -87,8 +94,10 @@ export default class TestActionSheet extends React.Component {
         <Checkbox checked={lotItems} id="lot" onPress={(value) => this.setState({ lotItems: value })} label="Load lots of items" />
         <Checkbox checked={dangerItem} id="dangerItem" onPress={(value) => this.setState({ dangerItem: value })} label="Add danger item" />
         <Checkbox checked={imageSupport} id="imageSupport" onPress={(value) => this.setState({ imageSupport: value })} label="Render images for custom" />
+        <Checkbox checked={showDivider} id="showDivider" onPress={(value) => this.setState({ showDivider: value })} label="Show divider for custom" />
+        <Checkbox checked={fullBleed} id="fullBleed" onPress={(value) => this.setState({ fullBleed: value })} label="Full bleed for custom" />
         <Button onPress={this.openActionSheeet} text="Open action sheet" style={styles.button} />
-        <ActionSheet open={open} title="Action sheet title" body={showBody ? 'Useful info about what this action sheet does' : undefined} cancelButtonIndex={0} items={lotItems ? [...this.items, ...this.items, ...this.items, ...this.items] : this.items} forceCustomActionSheet={forceCustom} />
+        <ActionSheet open={open} title="Action sheet title" body={showBody ? 'Useful info about what this action sheet does' : undefined} cancelButtonIndex={0} items={lotItems ? [...this.items, ...this.items, ...this.items, ...this.items] : this.items} fullBleed={fullBleed} forceCustomActionSheet={forceCustom} />
       </ScrollView>
     );
   }

--- a/example/src/Views/Dropdown.tsx
+++ b/example/src/Views/Dropdown.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { StyleSheet, ScrollView, View } from 'react-native';
-import { Dropdown, DropdownItem } from '@carbon/react-native';
+import { Dropdown, DropdownItem, getColor } from '@carbon/react-native';
+import CodeIcon from '@carbon/icons/es/code/20';
 
 const styles = StyleSheet.create({
   view: {
@@ -48,6 +49,8 @@ export default class TestDropdown extends React.Component {
       {
         id: '4',
         text: 'Item 4',
+        icon: CodeIcon,
+        iconColor: getColor('supportError'),
       },
       {
         text: 'Item 5',
@@ -59,7 +62,7 @@ export default class TestDropdown extends React.Component {
       },
       {
         id: '67',
-        text: 'Item 7',
+        text: 'Super long item with text that will not fit most views but should wrap in the dropdown but on the main view should ellipsis.',
       },
     ];
   }

--- a/example/src/Views/FormItem.tsx
+++ b/example/src/Views/FormItem.tsx
@@ -31,6 +31,7 @@ export default class TestFormItem extends React.Component {
     age: '',
     birthDay: '',
     toggleTest: false,
+    renderLeft: false,
     volume: '35',
     paymentType: 'card',
   };
@@ -40,17 +41,18 @@ export default class TestFormItem extends React.Component {
   };
 
   render(): React.ReactNode {
-    const { firstName, password, textArea, age, birthDay, toggleTest, volume, paymentType } = this.state;
+    const { firstName, password, textArea, age, birthDay, toggleTest, volume, paymentType, renderLeft } = this.state;
 
     return (
       <ScrollView keyboardShouldPersistTaps="handled" contentInsetAdjustmentBehavior="automatic" contentContainerStyle={styles.container} style={styles.view}>
         <FormItem type="header" label="Choose payment type" helperText="Select a payment type to complete purchase" />
-        <FormItem type="checkbox" overrideActiveCheckboxIcon={RadioIcon} label="Credit card" helperText="All major cards accepted" value={paymentType === 'card'} onChange={() => this.setState({ paymentType: 'card' })} />
-        <FormItem type="checkbox" overrideActiveCheckboxIcon={RadioIcon} label="Electronic check" value={paymentType === 'check'} onChange={() => this.setState({ paymentType: 'check' })} />
-        <FormItem type="checkbox" overrideActiveCheckboxIcon={RadioIcon} label="Cash on delivery" value={paymentType === 'cash'} onChange={() => this.setState({ paymentType: 'cash' })} />
+        <FormItem type="checkbox" renderToggleCheckboxLeft={renderLeft} overrideActiveCheckboxIcon={RadioIcon} label="Credit card" helperText="All major cards accepted" value={paymentType === 'card'} onChange={() => this.setState({ paymentType: 'card' })} />
+        <FormItem type="checkbox" renderToggleCheckboxLeft={renderLeft} overrideActiveCheckboxIcon={RadioIcon} label="Electronic check" value={paymentType === 'check'} onChange={() => this.setState({ paymentType: 'check' })} />
+        <FormItem type="checkbox" renderToggleCheckboxLeft={renderLeft} overrideActiveCheckboxIcon={RadioIcon} label="Cash on delivery" value={paymentType === 'cash'} onChange={() => this.setState({ paymentType: 'cash' })} />
         <FormItem type="header" label="Example header" helperText="Helper text to explain what the form section below includes" />
         <FormItem type="text" label="First name" helperText="This will be your first name" value={firstName} onChange={(value) => this.setState({ firstName: value })} textInputProps={{ required: true, getErrorText: () => 'Item is required', placeholder: 'Required' }} />
-        <FormItem type="toggle" label="Raise to wake" value={toggleTest} onChange={(value) => this.setState({ toggleTest: value })} toggleValueText={(value) => (value ? 'On' : 'Off')} />
+        <FormItem type="toggle" label="Raise to wake" value={toggleTest} renderToggleCheckboxLeft={renderLeft} onChange={(value) => this.setState({ toggleTest: value })} toggleValueText={(value) => (value ? 'On' : 'Off')} />
+        <FormItem type="toggle" label="Move to left" helperText="Move checkbox/toggle to left side" value={renderLeft} renderToggleCheckboxLeft={renderLeft} onChange={(value) => this.setState({ renderLeft: value })} toggleValueText={(value) => (value ? 'On' : 'Off')} />
         <FormItem type="password" label="Password" value={password} onChange={(value) => this.setState({ password: value })} />
         <FormItem type="text-area" lastItem={true} label="Text area" value={textArea} onChange={(value) => this.setState({ textArea: value })} />
         <FormItem type="header" label="Additional content" helperText="Provide more info here" />

--- a/example/src/Views/Menu.tsx
+++ b/example/src/Views/Menu.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { StyleSheet, ScrollView, View, Alert } from 'react-native';
-import { Menu, MenuItemProps } from '@carbon/react-native';
+import { Checkbox, Menu, MenuItemProps, getColor } from '@carbon/react-native';
+import CodeIcon from '@carbon/icons/es/code/20';
 
 const styles = StyleSheet.create({
   view: {
@@ -18,42 +19,67 @@ const styles = StyleSheet.create({
 });
 
 export default class TestMenu extends React.Component {
+  state = {
+    showIcons: false,
+    changeIconColor: false,
+    showDivider: false,
+  };
+
   private alert = (text: string): void => {
     Alert.alert(text);
   };
 
   private get regular(): MenuItemProps[] {
+    const { showIcons, changeIconColor, showDivider } = this.state;
+
     return [
       {
         text: 'Item 1',
         onPress: () => this.alert('Item 1 pressed'),
         onLongPress: () => this.alert('Item 1 long pressed'),
+        icon: showIcons ? CodeIcon : undefined,
+        iconColor: changeIconColor ? getColor('supportSuccess') : undefined,
+        divider: showDivider,
       },
       {
         text: 'Item 2 with really long text that will go into ellipsis instead of wrapping like the one below',
         textBreakMode: 'tail',
         onPress: () => this.alert('Item 2 pressed'),
+        icon: showIcons ? CodeIcon : undefined,
+        iconColor: changeIconColor ? getColor('supportSuccess') : undefined,
+        divider: showDivider,
       },
       {
         text: 'Item 3',
         disabled: true,
         onPress: () => this.alert('Item 3 pressed'),
         onLongPress: () => this.alert('Item 3 long pressed'),
+        icon: showIcons ? CodeIcon : undefined,
+        iconColor: changeIconColor ? getColor('supportSuccess') : undefined,
+        divider: showDivider,
       },
       {
         text: 'Item 4 with really long name for wrapping the text and not going to ellipsis',
         onPress: () => this.alert('Item 4 pressed'),
         onLongPress: () => this.alert('Item 4 long pressed'),
+        icon: showIcons ? CodeIcon : undefined,
+        iconColor: changeIconColor ? getColor('supportSuccess') : undefined,
+        divider: showDivider,
       },
     ];
   }
 
   private get many(): MenuItemProps[] {
+    const { showIcons, changeIconColor, showDivider } = this.state;
+
     const getItem = (num: number): MenuItemProps => {
       return {
         text: `Item ${num}`,
         onPress: () => this.alert(`Item ${num} pressed`),
         onLongPress: () => this.alert(`Item ${num}1 long pressed`),
+        icon: showIcons ? CodeIcon : undefined,
+        iconColor: changeIconColor ? getColor('supportSuccess') : undefined,
+        divider: showDivider,
       };
     };
 
@@ -69,8 +95,13 @@ export default class TestMenu extends React.Component {
   }
 
   render(): React.ReactNode {
+    const { showIcons, changeIconColor, showDivider } = this.state;
+
     return (
       <ScrollView keyboardShouldPersistTaps="handled" contentInsetAdjustmentBehavior="automatic" contentContainerStyle={styles.container} style={styles.view}>
+        <Checkbox checked={showIcons} id="showIcons" onPress={(value) => this.setState({ showIcons: value })} label="Show icons" />
+        <Checkbox checked={changeIconColor} id="changeIconColor" onPress={(value) => this.setState({ changeIconColor: value })} label="Render icon in custom color" />
+        <Checkbox checked={showDivider} id="showDivider" onPress={(value) => this.setState({ showDivider: value })} label="Show Divider" />
         <View style={styles.itemStyle}>
           <Menu items={this.regular} />
         </View>

--- a/example/src/Views/TextInput.tsx
+++ b/example/src/Views/TextInput.tsx
@@ -24,6 +24,7 @@ export default class TestTextInput extends React.Component {
     value5: '',
     value6: 'Can not change me',
     value7: '',
+    value8: '',
   };
 
   private changeText = (field: string, value: string): void => {
@@ -31,7 +32,7 @@ export default class TestTextInput extends React.Component {
   };
 
   render(): React.ReactNode {
-    const { value1, value2, value3, value4, value5, value6, value7 } = this.state;
+    const { value1, value2, value3, value4, value5, value6, value7, value8 } = this.state;
 
     return (
       <ScrollView keyboardShouldPersistTaps="handled" contentInsetAdjustmentBehavior="automatic" contentContainerStyle={styles.container} style={styles.view}>
@@ -52,6 +53,9 @@ export default class TestTextInput extends React.Component {
         </View>
         <View style={styles.itemStyle}>
           <TextInput label="I can be invalid" isInvalid={(value) => value?.toLowerCase().indexOf('https') !== 0} value={value7} placeholder="I must start with https or will error" onChangeText={(value) => this.changeText('value7', value)} getErrorText={() => 'Must start with https'} />
+        </View>
+        <View style={styles.itemStyle}>
+          <TextInput label="I have a warning" required={true} value={value8} warningText="Here is a warning" helperText="I am helper text that is really long explaining how this input should work and stuff" onChangeText={(value) => this.changeText('value8', value)} getErrorText={() => 'This is required.'} />
         </View>
         <View style={styles.itemStyle}>
           <TextInput label="I am disabled" disabled={true} value={value6} onChangeText={(value) => this.changeText('value6', value)} />

--- a/src/components/ActionSheet/index.tsx
+++ b/src/components/ActionSheet/index.tsx
@@ -24,6 +24,8 @@ export type ActionSheetItem = {
   };
   /** Press event (this will also automatically close the ActionSheet as well) */
   onPress: () => void;
+  /** Indicate that divider should be rendered (does not apply to last item, and only for non system ActionSheet) */
+  divider?: boolean;
 };
 
 export type ActionSheetProps = {
@@ -39,6 +41,8 @@ export type ActionSheetProps = {
   open: boolean;
   /** Force use of the custom action sheet (even if System is supported) */
   forceCustomActionSheet?: boolean;
+  /** Indicate that Action Sheet should go full bleed */
+  fullBleed?: boolean;
 };
 
 /**
@@ -47,6 +51,8 @@ export type ActionSheetProps = {
  */
 export class ActionSheet extends React.Component<ActionSheetProps> {
   private get styles() {
+    const { fullBleed } = this.props;
+
     return StyleSheet.create({
       modal: {
         zIndex: zIndexes.actionSheet,
@@ -60,7 +66,7 @@ export class ActionSheet extends React.Component<ActionSheetProps> {
       containerWrapper: {
         flexGrow: 1,
         flexDirection: 'row-reverse',
-        margin: 16,
+        margin: fullBleed ? 0 : 16,
         maxWidth: 480,
       },
       blurBackground: {
@@ -205,6 +211,7 @@ export class ActionSheet extends React.Component<ActionSheetProps> {
                 <ScrollView bounces={false} style={this.styles.options}>
                   {options.map((item, index) => {
                     const finalStyle = styleReferenceBreaker(this.styles.option);
+                    const lastItem = index === options.length - 1;
 
                     let imageItem: React.ReactNode | undefined;
 
@@ -216,6 +223,11 @@ export class ActionSheet extends React.Component<ActionSheetProps> {
 
                     if (item.danger) {
                       finalStyle.backgroundColor = getColor('buttonDangerPrimary');
+                    }
+
+                    if (item.divider && !lastItem) {
+                      finalStyle.borderBottomColor = finalStyle.borderBottomColor || getColor('borderSubtle00');
+                      finalStyle.borderBottomWidth = finalStyle.borderBottomWidth || 1;
                     }
 
                     return (

--- a/src/components/BaseTextInputs/index.tsx
+++ b/src/components/BaseTextInputs/index.tsx
@@ -8,7 +8,8 @@ import ViewIcon from '@carbon/icons/es/view/20';
 import ViewOffIcon from '@carbon/icons/es/view--off/20';
 import SubtractIcon from '@carbon/icons/es/subtract/20';
 import CalendarIcon from '@carbon/icons/es/calendar/20';
-import WarningFilledIcon from '@carbon/icons/es/warning--filled/20';
+import WarningIcon from '@carbon/icons/es/warning--alt--filled/20';
+import ErrorIcon from '@carbon/icons/es/warning--filled/20';
 import AddIcon from '@carbon/icons/es/add/20';
 import { defaultText } from '../../constants/defaultText';
 import { BodyCompact02, Body02 } from '../../styles/typography';
@@ -36,6 +37,8 @@ export type TextInputProps = {
   isInvalid?: (value: string) => boolean;
   /** Error string to use. Set custom rules or return required text */
   getErrorText?: (value: string) => string;
+  /** Warning string to use. This will show if NOT in error. */
+  warningText?: string;
   /** Placeholder text to use */
   placeholder?: string;
   /** Indicate if required */
@@ -139,6 +142,10 @@ export const getTextInputStyle = (light?: boolean, hasLabelLink?: boolean, fullB
     },
     errorText: {
       color: getColor('textError'),
+      marginTop: 8,
+      marginBottom: fullBleed ? 8 : undefined,
+    },
+    warningText: {
       marginTop: 8,
       marginBottom: fullBleed ? 8 : undefined,
     },
@@ -282,7 +289,7 @@ export class BaseTextInput extends React.Component<BaseTextInputProps & TextInpu
     return <View style={this.styles.dateIcon}>{createIcon(CalendarIcon, 20, 20, disabled ? getColor('iconDisabled') : getColor('iconSecondary'))}</View>;
   }
 
-  private get errorIndicator(): React.ReactNode {
+  private get baseErrorWarningStyle() {
     const { type } = this.props;
     let errorIconStyle = styleReferenceBreaker(this.styles.errorIcon);
 
@@ -296,7 +303,15 @@ export class BaseTextInput extends React.Component<BaseTextInputProps & TextInpu
       errorIconStyle.paddingLeft = 0;
     }
 
-    return <View style={errorIconStyle}>{createIcon(WarningFilledIcon, 20, 20, getColor('supportError'))}</View>;
+    return errorIconStyle;
+  }
+
+  private get errorIndicator(): React.ReactNode {
+    return <View style={this.baseErrorWarningStyle}>{createIcon(ErrorIcon, 20, 20, getColor('supportError'))}</View>;
+  }
+
+  private get warningIndicator(): React.ReactNode {
+    return <View style={this.baseErrorWarningStyle}>{createIcon(WarningIcon, 20, 20, getColor('supportWarning'))}</View>;
   }
 
   private incrementNumber = (): void => {
@@ -344,7 +359,7 @@ export class BaseTextInput extends React.Component<BaseTextInputProps & TextInpu
   }
 
   render(): React.ReactNode {
-    const { label, helperText, getErrorText, value, autoCorrect, autoCapitalize, placeholder, maxLength, onSubmitEditing, componentProps, style, required, disabled, isInvalid, type, textAreaMinHeight, labelBreakMode, labelLink, fullBleedCallback } = this.props;
+    const { label, helperText, getErrorText, value, autoCorrect, autoCapitalize, placeholder, maxLength, onSubmitEditing, componentProps, style, required, disabled, isInvalid, type, textAreaMinHeight, labelBreakMode, labelLink, fullBleedCallback, warningText } = this.props;
     const { hasFocus, dirty, revealPassword } = this.state;
     const password = type === 'password';
     const textArea = type === 'text-area';
@@ -394,12 +409,14 @@ export class BaseTextInput extends React.Component<BaseTextInputProps & TextInpu
         <View style={this.styles.textBoxWrapper} accessible={password}>
           <ReactTextInput editable={!disabled} accessibilityLabel={helperText ? `${label} - ${helperText}` : label} secureTextEntry={revealPassword ? false : password} autoCapitalize={autoCapitalize} style={textBoxStyle} value={value} onSubmitEditing={onSubmitEditing} onChangeText={this.onChange} autoCorrect={autoCorrect} placeholder={placeholder} placeholderTextColor={getColor('textPlaceholder')} onBlur={this.onBlur} onFocus={this.onFocus} maxLength={maxLength} textAlignVertical="top" multiline={textArea} {...(componentProps || {})} />
           {error && this.errorIndicator}
+          {!!(warningText && !error) && this.warningIndicator}
           {password && this.passwordReveal}
           {date && this.dateIcon}
           {number && this.numberActions}
         </View>
-        {!!(helperText && !error) && <Text style={this.styles.helperText} type="helper-text-02" text={helperText} />}
+        {!!(helperText && !error && !warningText) && <Text style={this.styles.helperText} type="helper-text-02" text={helperText} />}
         {!!(typeof getErrorText === 'function' && error) && <Text style={this.styles.errorText} type="helper-text-02" text={getErrorText(value)} />}
+        {!!(warningText && !error) && <Text style={this.styles.warningText} type="helper-text-02" text={warningText} />}
       </View>
     );
   }

--- a/src/components/BaseTextInputs/index.tsx
+++ b/src/components/BaseTextInputs/index.tsx
@@ -133,7 +133,7 @@ export const getTextInputStyle = (light?: boolean, hasLabelLink?: boolean, fullB
       color: getColor('textSecondary'),
       flex: 1,
       paddingTop: hasLabelLink ? 30 : undefined,
-      marginBottom: 8,
+      marginBottom: fullBleed ? 5 : 8,
     },
     helperText: {
       color: getColor('textHelper'),

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ViewProps, StyleProp, StyleSheet, ViewStyle, View, Pressable, Modal as ReactModal, PressableStateCallbackType, Dimensions } from 'react-native';
 import { getColor, shadowStyle } from '../../styles/colors';
 import { createIcon, pressableFeedbackStyle, styleReferenceBreaker } from '../../helpers';
-import { maxMenuHeight, Menu } from '../Menu';
+import { Menu } from '../Menu';
 import { getTextInputStyle } from '../BaseTextInputs';
 import { Text, TextBreakModes, TextTypes } from '../Text';
 import type { MenuItemProps } from '../MenuItem';
@@ -11,6 +11,7 @@ import ChevronUpIcon from '@carbon/icons/es/chevron--up/20';
 import { modalPresentations } from '../../constants/constants';
 import { zIndexes } from '../../styles/z-index';
 import { defaultText } from '../../constants/defaultText';
+import { CarbonIcon } from '../../types/shared';
 
 export type DropdownItem = {
   /** ID for tracking items */
@@ -23,6 +24,12 @@ export type DropdownItem = {
   disabled?: boolean;
   /** Text type to render (Standard is default.  Normally only body 01 or 02 should be used)  */
   textType?: TextTypes;
+  /** Set to an icon from Carbon (size 20). */
+  icon?: CarbonIcon;
+  /** Color of the icon (default is primary text) */
+  iconColor?: string;
+  /** Indicate that divider should be rendered (does not apply to last item) */
+  divider?: boolean;
   /** Indicate if keyboard should be dismissed onPress */
   dismissKeyboardOnPress?: boolean;
 };
@@ -48,6 +55,8 @@ export type DropdownProps = {
   light?: boolean;
   /** Text to use for on close areas (accessibility). Defaults to ENGLISH "Close" */
   closeText?: string;
+  /** Height in pixels to max out the menu (defaults to 280) */
+  maxMenuHeight?: number;
   /** Style to set on the item */
   style?: StyleProp<ViewStyle>;
   /** Direct props to set on the React Native component (including iOS and Android specific props). Most use cases should not need this. */
@@ -72,6 +81,7 @@ export class Dropdown extends React.Component<DropdownProps> {
 
   private get styles() {
     const { renderLeft, renderRight, renderTop, renderBottom, inverseMenu } = this.state;
+    const { maxMenuHeight } = this.props;
 
     return StyleSheet.create({
       modal: {
@@ -95,7 +105,7 @@ export class Dropdown extends React.Component<DropdownProps> {
         bottom: renderBottom,
         right: renderRight,
         left: renderLeft,
-        maxHeight: inverseMenu ? undefined : maxMenuHeight,
+        maxHeight: inverseMenu ? undefined : maxMenuHeight || 280,
         flexDirection: inverseMenu ? 'column-reverse' : undefined,
         ...shadowStyle,
       },
@@ -106,6 +116,7 @@ export class Dropdown extends React.Component<DropdownProps> {
       },
       dropdownText: {
         color: this.itemColor,
+        paddingRight: 32,
       },
     });
   }
@@ -209,7 +220,7 @@ export class Dropdown extends React.Component<DropdownProps> {
         {!!label && <Text style={this.textInputStyles.label} type="label-02" text={label} />}
         <View style={this.styles.innerWrapper}>
           <Pressable disabled={disabled} style={(state) => pressableFeedbackStyle(state, finalStyle, this.getStateStyle)} accessibilityLabel={label} accessibilityHint={currentText} onPress={this.toggleDropdown} ref={this.setFormItemRef}>
-            <Text text={currentText || unsetText} style={this.styles.dropdownText} />
+            <Text text={currentText || unsetText} breakMode="tail" style={this.styles.dropdownText} />
             {this.dropdownIcon}
           </Pressable>
           {open && (

--- a/src/components/FormItem/index.tsx
+++ b/src/components/FormItem/index.tsx
@@ -57,6 +57,8 @@ export type FormItemProps = {
   toggleValueText?: (value: boolean) => string;
   /** Override icon for select item (default is Checkbox) */
   overrideActiveCheckboxIcon?: CarbonIcon;
+  /** Indicate that toggle or checkbox should render on the left side. Default is right */
+  renderToggleCheckboxLeft?: boolean;
   /** Slider props for customizing slider */
   sliderProps?: {
     /** Icon to render on right side of slider */
@@ -106,14 +108,16 @@ export class FormItem extends React.Component<FormItemProps> {
   }
 
   private get styles() {
-    const { type, disabled } = this.props;
+    const { type, disabled, renderToggleCheckboxLeft } = this.props;
     const noRightPadding = ['password', 'number', 'date'].includes(type);
     const noBottomPadding = this.noBottomPadding;
+    const helperTextColor = getColor(disabled ? 'textDisabled' : 'textHelper');
 
     const baseWrapper = styleReferenceBreaker(getNavigationListItemStyle(), {
       flexDirection: 'column',
       padding: 14,
-      paddingRight: noRightPadding ? 0 : 14,
+      paddingRight: noRightPadding ? 0 : 16,
+      paddingLeft: noRightPadding ? 0 : 16,
       paddingBottom: noBottomPadding ? 0 : 14,
       borderColor: 'transparent',
       borderWidth: 2,
@@ -138,6 +142,10 @@ export class FormItem extends React.Component<FormItemProps> {
       headerContent: {
         color: getColor('textSecondary'),
       },
+      headerContentDescription: {
+        color: getColor('textSecondary'),
+        paddingTop: 4,
+      },
       staticText: {
         paddingTop: 8,
         color: getColor('textSecondary'),
@@ -155,6 +163,7 @@ export class FormItem extends React.Component<FormItemProps> {
         flex: 1,
         paddingTop: 13,
         paddingBottom: 13,
+        paddingLeft: renderToggleCheckboxLeft ? 30 : undefined,
       },
       toggleWrapper: {
         paddingTop: 0,
@@ -169,15 +178,20 @@ export class FormItem extends React.Component<FormItemProps> {
         flex: 1,
       },
       helperText: {
-        color: getColor(disabled ? 'textDisabled' : 'textHelper'),
+        color: helperTextColor,
       },
       checkboxButton: {
         ...baseWrapper,
         flex: 1,
         flexDirection: 'row',
       },
+      checkboxHelperText: {
+        color: helperTextColor,
+        marginTop: 0,
+      },
       checkboxTextWrapper: {
         flex: 1,
+        paddingLeft: renderToggleCheckboxLeft ? 30 : undefined,
       },
     });
   }
@@ -207,11 +221,11 @@ export class FormItem extends React.Component<FormItemProps> {
     const items = [];
 
     if (label) {
-      items.push(<Text key="label" style={this.styles.headerContent} type="heading-compact-02" text={label} />);
+      items.push(<Text key="label" style={this.styles.headerContent} type="heading-compact-01" text={label} />);
     }
 
     if (helperText) {
-      items.push(<Text key="helperText" style={this.styles.headerContent} type="helper-text-01" text={helperText} />);
+      items.push(<Text key="helperText" style={this.styles.headerContentDescription} type="helper-text-01" text={helperText} />);
     }
 
     if (descriptionFirstHeader) {
@@ -240,18 +254,15 @@ export class FormItem extends React.Component<FormItemProps> {
   }
 
   private get toggleContent(): React.ReactNode {
-    const { label, textBreakMode, disabled, value, toggleValueText } = this.props;
+    const { label, textBreakMode, disabled, value, toggleValueText, renderToggleCheckboxLeft } = this.props;
 
     const changeValue = (textValue: boolean) => {
       this.triggerChange(textValue);
     };
 
-    return (
-      <>
-        <Text text={typeof toggleValueText === 'function' ? toggleValueText(!!value) : String(value)} style={this.styles.toggleText} breakMode={textBreakMode} />
-        <Toggle label={label || ''} style={this.styles.toggleWrapper} toggleWrapperStyle={this.styles.toggleDirectWrapper} hideLabel={true} disabled={disabled} toggled={!!value} onChange={changeValue} />
-      </>
-    );
+    const items = [<Text key="label" text={typeof toggleValueText === 'function' ? toggleValueText(!!value) : String(value)} style={this.styles.toggleText} breakMode={textBreakMode} />, <Toggle key="toggle" label={label || ''} style={this.styles.toggleWrapper} toggleWrapperStyle={this.styles.toggleDirectWrapper} hideLabel={true} disabled={disabled} toggled={!!value} onChange={changeValue} />];
+
+    return renderToggleCheckboxLeft ? items.reverse() : items;
   }
 
   private get staticContent(): React.ReactNode {
@@ -277,19 +288,23 @@ export class FormItem extends React.Component<FormItemProps> {
   }
 
   private get checkboxContent(): React.ReactNode {
-    const { label, textBreakMode, disabled, value, helperText, overrideActiveCheckboxIcon } = this.props;
+    const { label, textBreakMode, disabled, value, helperText, overrideActiveCheckboxIcon, renderToggleCheckboxLeft } = this.props;
 
     const changeValue = () => {
       this.triggerChange(!value);
     };
 
+    const items = [
+      <View style={this.styles.checkboxTextWrapper} key="label">
+        <Text text={label} breakMode={textBreakMode} />
+        {!!helperText && <Text type="helper-text-02" style={styleReferenceBreaker(getTextInputStyle().helperText, this.styles.checkboxHelperText)} text={helperText} />}
+      </View>,
+      createIcon(value ? overrideActiveCheckboxIcon || CheckmarkIcon : EmptyCheckmarkIcon, 20, 20, this.mainColor, 'icon'),
+    ];
+
     return (
       <Pressable style={this.styles.checkboxButton} disabled={disabled} accessibilityLabel={label} accessibilityRole="button" onPress={changeValue}>
-        <View style={this.styles.checkboxTextWrapper}>
-          <Text text={label} breakMode={textBreakMode} />
-          {!!helperText && <Text type="helper-text-02" style={styleReferenceBreaker(getTextInputStyle().helperText, this.styles.helperText)} text={helperText} />}
-        </View>
-        {createIcon(value ? overrideActiveCheckboxIcon || CheckmarkIcon : EmptyCheckmarkIcon, 20, 20, this.mainColor)}
+        {renderToggleCheckboxLeft ? items.reverse() : items}
       </Pressable>
     );
   }

--- a/src/components/FormItem/index.tsx
+++ b/src/components/FormItem/index.tsx
@@ -117,7 +117,7 @@ export class FormItem extends React.Component<FormItemProps> {
       flexDirection: 'column',
       padding: 14,
       paddingRight: noRightPadding ? 0 : 16,
-      paddingLeft: noRightPadding ? 0 : 16,
+      paddingLeft: 16,
       paddingBottom: noBottomPadding ? 0 : 14,
       borderColor: 'transparent',
       borderWidth: 2,

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -7,20 +7,21 @@ import { MenuItem, MenuItemProps } from '../MenuItem';
 export type MenuProps = {
   /** Items to render in the menu */
   items: MenuItemProps[];
+  /** Height in pixels to max out the menu (defaults to 280) */
+  maxMenuHeight?: number;
   /** Style to set on the item */
   style?: StyleProp<ViewStyle>;
   /** Direct props to set on the React Native component (including iOS and Android specific props). Most use cases should not need this. */
   componentProps?: ViewProps;
 };
 
-/** Max menu height */
-export const maxMenuHeight = 280;
-
 export class Menu extends React.Component<MenuProps> {
   private get styles() {
+    const { maxMenuHeight } = this.props;
+
     return StyleSheet.create({
       wrapper: {
-        maxHeight: maxMenuHeight,
+        maxHeight: maxMenuHeight || 280,
         backgroundColor: getColor('layer01'),
       },
     });
@@ -28,11 +29,12 @@ export class Menu extends React.Component<MenuProps> {
 
   render(): React.ReactNode {
     const { items, componentProps, style } = this.props;
+    const finalItems = items || [];
 
     return (
       <ScrollView bounces={false} style={styleReferenceBreaker(this.styles.wrapper, style)} accessibilityRole="menu" {...(componentProps || {})}>
-        {(items || []).map((item, index) => (
-          <MenuItem key={index} {...item} />
+        {finalItems.map((item, index) => (
+          <MenuItem key={index} {...item} lastItem={index === finalItems.length - 1} />
         ))}
       </ScrollView>
     );

--- a/src/components/MenuItem/index.tsx
+++ b/src/components/MenuItem/index.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { GestureResponderEvent, Keyboard, Pressable, PressableProps, StyleProp, StyleSheet, TextStyle, ViewStyle, PressableStateCallbackType } from 'react-native';
-import { pressableFeedbackStyle, styleReferenceBreaker } from '../../helpers';
+import { GestureResponderEvent, Keyboard, Pressable, PressableProps, StyleProp, StyleSheet, TextStyle, ViewStyle, PressableStateCallbackType, View } from 'react-native';
+import { createIcon, pressableFeedbackStyle, styleReferenceBreaker } from '../../helpers';
 import { getColor } from '../../styles/colors';
 import { Text, TextBreakModes, TextTypes } from '../Text';
+import { CarbonIcon } from '../../types/shared';
 
 export type MenuItemProps = {
   /** Text to render */
@@ -13,6 +14,14 @@ export type MenuItemProps = {
   disabled?: boolean;
   /** Text type to render (Standard is default.  Normally only body 01 or 02 should be used)  */
   textType?: TextTypes;
+  /** Set to an icon from Carbon (size 20). */
+  icon?: CarbonIcon;
+  /** Color of the icon (default is primary text) */
+  iconColor?: string;
+  /** Indicate that divider should be rendered (does not apply to last item) */
+  divider?: boolean;
+  /** Indicates that menu item is final item (this is used internally) */
+  lastItem?: boolean;
   /** onPress event */
   onPress: (event: GestureResponderEvent) => void;
   /** onLongPress event */
@@ -27,21 +36,44 @@ export type MenuItemProps = {
 
 export class MenuItem extends React.Component<MenuItemProps> {
   private get styles() {
+    const { divider, lastItem } = this.props;
+
     return StyleSheet.create({
       wrapper: {
-        paddingRight: 16,
-        paddingLeft: 16,
-        paddingTop: 13,
-        paddingBottom: 13,
+        padding: 14,
+        flex: 1,
+        flexDirection: 'row',
+        alignItems: 'flex-start',
+        borderBottomColor: divider && !lastItem ? getColor('borderSubtle00') : undefined,
+        borderBottomWidth: divider && !lastItem ? 1 : undefined,
+      },
+      icon: {
+        paddingTop: 2,
+        paddingRight: 14,
       },
     });
   }
 
-  private get textStyle(): StyleProp<TextStyle> {
+  private get textColor(): string {
     const { disabled } = this.props;
 
+    return getColor(disabled ? 'textDisabled' : 'textSecondary');
+  }
+
+  private get iconColor(): string {
+    const { iconColor, disabled } = this.props;
+
+    if (disabled) {
+      return this.textColor;
+    }
+
+    return iconColor || this.textColor;
+  }
+
+  private get textStyle(): StyleProp<TextStyle> {
     let finalStyle: any = {
-      color: getColor(disabled ? 'textDisabled' : 'textSecondary'),
+      color: this.textColor,
+      flex: 1,
     };
 
     return StyleSheet.create(finalStyle);
@@ -64,10 +96,11 @@ export class MenuItem extends React.Component<MenuItemProps> {
   };
 
   render(): React.ReactNode {
-    const { text, disabled, onLongPress, componentProps, textType, style, textBreakMode } = this.props;
+    const { text, disabled, onLongPress, componentProps, textType, style, textBreakMode, icon } = this.props;
 
     return (
       <Pressable disabled={disabled} style={(state) => pressableFeedbackStyle(state, styleReferenceBreaker(this.styles.wrapper, style), this.getStateStyle)} accessibilityLabel={text} accessibilityRole="menuitem" onPress={this.onPress} onLongPress={onLongPress} {...(componentProps || {})}>
+        {!!icon && <View style={this.styles.icon}>{createIcon(icon, 20, 20, this.iconColor)}</View>}
         <Text breakMode={textBreakMode} type={textType} style={this.textStyle} text={text} />
       </Pressable>
     );

--- a/src/components/NavigationListItem/index.tsx
+++ b/src/components/NavigationListItem/index.tsx
@@ -223,17 +223,19 @@ export class NavigationListItem extends React.Component<NavigationListItemProps>
   };
 
   render(): React.ReactNode {
-    const { text, disabled, componentProps, style, leftIcon, rightIcon, hasChevron, lastItem, rightText } = this.props;
+    const { text, disabled, componentProps, style, leftIcon, rightIcon, hasChevron, lastItem, rightText, onPress, onLongPress } = this.props;
     const finalStyle = styleReferenceBreaker(this.styles.wrapper);
 
     if (lastItem) {
       finalStyle.borderBottomWidth = 0;
     }
 
+    const mainIsClickable = !!(typeof onPress === 'function' || typeof onLongPress === 'function');
+
     return (
       <View style={styleReferenceBreaker(finalStyle, style)}>
         {this.selectableAreaSide === 'left' && this.selectableArea}
-        <Pressable disabled={disabled} style={(state) => pressableFeedbackStyle(state, this.styles.pressableStyle, this.getStateStyle)} accessibilityLabel={text} accessibilityRole="button" onPress={this.onPress} onLongPress={this.onLongPress} {...(componentProps || {})}>
+        <Pressable disabled={disabled} style={(state) => (mainIsClickable ? pressableFeedbackStyle(state, this.styles.pressableStyle, this.getStateStyle) : this.styles.pressableStyle)} accessibilityLabel={text} accessibilityRole="button" onPress={this.onPress} onLongPress={this.onLongPress} {...(componentProps || {})}>
           {!!leftIcon && <View style={this.styles.leftIcon}>{createIcon(leftIcon, 20, 20, this.textIconColor)}</View>}
           {this.contentArea}
           {!!rightText && (

--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -33,6 +33,8 @@ export class Pagination extends React.Component<PaginationProps> {
       },
       item: {
         padding: 8,
+        paddingLeft: 4,
+        paddingRight: 4,
       },
     });
   }

--- a/src/components/Toggle/index.tsx
+++ b/src/components/Toggle/index.tsx
@@ -44,10 +44,10 @@ export class Toggle extends React.Component<ToggleProps> {
       },
       switchWrapper: {
         flexDirection: 'row',
-        paddingTop: 16,
+        paddingTop: 4,
       },
       selectedText: {
-        marginLeft: 12,
+        marginLeft: 8,
         marginTop: 4,
       },
     });

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -165,7 +165,7 @@ export class Tooltip extends React.Component<TooltipProps> {
     return (
       <View style={styleReferenceBreaker(this.styles.wrapper, style)} accessibilityRole="menu" {...(componentProps || {})}>
         <View>
-          {linkProps ? <Link {...linkProps} onPress={this.toggleTooltip} forwardRef={this.setFormItemRef} /> : <Button {...(buttonProps || { text: '' })} onPress={this.toggleTooltip} forwardRef={this.setFormItemRef} />}
+          {linkProps ? <Link {...linkProps} onPress={this.toggleTooltip} forwardRef={this.setFormItemRef} /> : <Button {...(buttonProps || { text: '' })} overrideColor={buttonProps?.iconOnlyMode ? (open ? getColor('iconPrimary') : getColor('iconSecondary')) : undefined} onPress={this.toggleTooltip} forwardRef={this.setFormItemRef} />}
           {open && (
             <ReactModal style={this.styles.modal} supportedOrientations={modalPresentations} transparent={true} onRequestClose={() => this.setState({ open: false })}>
               <Pressable style={this.styles.closeModal} accessibilityRole="button" accessibilityLabel={closeText || defaultText.close} onPress={this.closeTooltip} />

--- a/src/helpers/index.tsx
+++ b/src/helpers/index.tsx
@@ -26,16 +26,16 @@ export const logIssue = (issue: string, data: unknown): void => {
  *
  * @returns - React Node to render on the screen.  If the icon fails to be created an X icon is rendered.
  */
-export const createIcon = (icon: CarbonIcon, width?: string | number, height?: string | number, color?: string): React.ReactNode => {
+export const createIcon = (icon: CarbonIcon, width?: string | number, height?: string | number, color?: string, key?: string | number): React.ReactNode => {
   try {
     const iconString = toString(icon) as string;
 
-    return <SvgXml color={color || getColor('iconPrimary')} xml={iconString} width={width || '100%'} height={height || '100%'} />;
+    return <SvgXml color={color || getColor('iconPrimary')} xml={iconString} width={width || '100%'} height={height || '100%'} key={key} />;
   } catch (error) {
     logIssue('createIcon: failed to create the icon', error);
     const backupIcon = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 13.17 13.69"><line x1="0.71" y1="0.97" x2="12.46" y2="12.72" fill="currentColor" stroke="currentColor" stroke-miterlimit="10" stroke-width="2"/><line x1="1.02" y1="13.02" x2="12.15" y2="0.67" fill="currentColor" stroke="currentColor" stroke-miterlimit="10" stroke-width="2"/></svg>';
 
-    return <SvgXml color={color || getColor('iconPrimary')} xml={backupIcon} width={width || '100%'} height={height || '100%'} />;
+    return <SvgXml color={color || getColor('iconPrimary')} xml={backupIcon} width={width || '100%'} height={height || '100%'} key={key} />;
   }
 };
 


### PR DESCRIPTION
Closes #114 (Tooltip icon colors)
Closes #115 (Menu/Dropdown icon support and max height props)
Closes #116 (FormItem left render toggle/checkbox)
Closes #117 (Toggle Spacing issues)
Closes #131 (Divider for Menu/Dropdown items)
Closes #132 (ActionSheet divider and full bleed)
Closes #121 (Pagination styling)
Closes #120 (Warning state for Text based input)
Closes #122 (Do not show state change for Navigation if no events)
Closes #126 (Header FormItem style fixes)
Closes #125 (Full bleed text spacing)

See each ticket for final implementation and comments