### PR TITLE
Attempt to fix release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - main2 # Disabling for now until we can get this working (https://github.com/carbon-design-system/carbon-react-native/issues/150)
+      - main
 jobs:
   build:
     if:


### PR DESCRIPTION
Part of #150 

@dabrad26 I actually already accidentally committed straight to main another change related to this that changes the env variable from GH_TOKEN to GITHUB_TOKEN.

Let's try this out and see if it works. If not I think there are two more things we could try:

1. Use a token from carbon-bot instead, and ensure carbon-bot is exempt from branch protection rules for `main`
2. Configure an SSH token [like the `gatsby-theme-carbon` project does](https://github.com/carbon-design-system/gatsby-theme-carbon/blob/37615427c548a64d83acd02091616fb623f50f08/.github/workflows/release.yml#L50-L57) to get around this. The SSH token can be configured against yours or my accounts.