### PR TITLE
Change Tertiary Button BorderOopacity onPress

### DIFF
--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -95,13 +95,10 @@ export class Button extends React.Component<ButtonProps> {
   }
 
   private getStateStyle = (state: PressableStateCallbackType): StyleProp<ViewStyle> => {
-    const { kind } = this.props;
-    const keepBorder = ['high-contrast', 'high-contrast-inverse'].includes(kind as string);
-
     return state.pressed
       ? {
           backgroundColor: this.getBackgroundColor(true),
-          borderWidth: keepBorder ? 1 : 0,
+          borderColor: 'rgba(0, 0, 0, 0)',
         }
       : undefined;
   };


### PR DESCRIPTION
### Problem Solved
- Currently, when a tertiary button is pressed, the 1px border from it is removed. This may cause the other elements in the page to shift by 1px (as shown in this [this video recording](https://github.com/carbon-design-system/carbon-react-native/assets/25396169/ab6202f2-d809-434e-8873-b29b84cd0904))

### What was Done
- Changed border opacity to 0 to hide the 1px border when a tertiary button is pressed


### How to Test
- Click on the tertiary button and ensure that the border disappears without shifting other elements by 1px


