### PR TITLE
feat: Move SafeZone logic to new library

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ yarn add @carbon/react-native
    - `@carbon/icon-helpers`
    - `react-native-svg`
    - `react-native-webview`
+   - `react-native-safe-area-context`
 
 **Important**: This library does not support EXPO by default. This library is designed and developed without EXPO.  If you are using EXPO you will need to do additioanl items to alter the build and setup to make it work. Please do not open tickets about issues with EXPO, the app is only tested to run with React Native.
 

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -15,6 +15,7 @@
         "@react-native-async-storage/async-storage": "^2.1.2",
         "react": "19.0.0",
         "react-native": "0.78.0",
+        "react-native-safe-area-context": "^5.3.0",
         "react-native-svg": "^15.11.2",
         "react-native-webview": "^13.13.2"
       },
@@ -6871,6 +6872,16 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-native-safe-area-context": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.3.0.tgz",
+      "integrity": "sha512-glV9bwuozTjf/JDBIBm+ITnukHNaUT3nucgdeADwjtHsfEN3RL5UO6nq99vvdWv5j/O9yCZBvFncM1BBQ+UvpQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/react-native-svg": {

--- a/example/package.json
+++ b/example/package.json
@@ -17,6 +17,7 @@
     "@react-native-async-storage/async-storage": "^2.1.2",
     "react": "19.0.0",
     "react-native": "0.78.0",
+    "react-native-safe-area-context": "^5.3.0",
     "react-native-svg": "^15.11.2",
     "react-native-webview": "^13.13.2"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "react": "19.0.0",
         "react-native": "0.78.0",
         "react-native-builder-bob": "^0.37.0",
+        "react-native-safe-area-context": "^5.3.0",
         "react-native-svg": "^15.11.2",
         "react-native-webview": "^13.13.2",
         "release-it": "^18.1.2",
@@ -15678,6 +15679,17 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-native-safe-area-context": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.3.0.tgz",
+      "integrity": "sha512-glV9bwuozTjf/JDBIBm+ITnukHNaUT3nucgdeADwjtHsfEN3RL5UO6nq99vvdWv5j/O9yCZBvFncM1BBQ+UvpQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/react-native-svg": {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "react": "19.0.0",
     "react-native": "0.78.0",
     "react-native-builder-bob": "^0.37.0",
+    "react-native-safe-area-context": "^5.3.0",
     "react-native-svg": "^15.11.2",
     "react-native-webview": "^13.13.2",
     "release-it": "^18.1.2",
@@ -88,7 +89,8 @@
     "react": "*",
     "react-native": "*",
     "react-native-svg": "*",
-    "react-native-webview": "*"
+    "react-native-webview": "*",
+    "react-native-safe-area-context": "*"
   },
   "jest": {
     "preset": "react-native",

--- a/src/components/ActionSheet/index.tsx
+++ b/src/components/ActionSheet/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { ActionSheetIOS, Platform, Pressable, PressableStateCallbackType, StyleProp, ViewStyle, ScrollView, StyleSheet, View, Modal as ReactModal, SafeAreaView, Image, ImageSourcePropType } from 'react-native';
+import { ActionSheetIOS, Platform, Pressable, PressableStateCallbackType, StyleProp, ViewStyle, ScrollView, StyleSheet, View, Modal as ReactModal, Image, ImageSourcePropType } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { createIcon, pressableFeedbackStyle, styleReferenceBreaker } from '../../helpers';
 import { modalPresentations } from '../../constants/constants';
 import { getColor } from '../../styles/colors';

--- a/src/components/DocumentViewer/index.tsx
+++ b/src/components/DocumentViewer/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { ViewProps, StyleProp, StyleSheet, ViewStyle, Modal as ReactModal, Platform, SafeAreaView, View, ScrollView } from 'react-native';
+import { ViewProps, StyleProp, StyleSheet, ViewStyle, Modal as ReactModal, Platform, View, ScrollView } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { styleReferenceBreaker } from '../../helpers';
 import { Overlay } from '../Overlay';
 import CloseIcon from '@carbon/icons/es/close/20';

--- a/src/components/GrantPermission/index.tsx
+++ b/src/components/GrantPermission/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { ViewProps, StyleProp, StyleSheet, ViewStyle, Modal as ReactModal, SafeAreaView, View, EmitterSubscription, Dimensions, Image, ScrollView, ImageSourcePropType, ImageStyle } from 'react-native';
+import { ViewProps, StyleProp, StyleSheet, ViewStyle, Modal as ReactModal, View, EmitterSubscription, Dimensions, Image, ScrollView, ImageSourcePropType, ImageStyle } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { getColor } from '../../styles/colors';
 import { modalPresentations } from '../../constants/constants';
 import { styleReferenceBreaker } from '../../helpers';

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Pressable, ScrollView, StyleSheet, View, Modal as ReactModal, GestureResponderEvent, SafeAreaView, PressableStateCallbackType, StyleProp, ViewStyle } from 'react-native';
+import { Pressable, ScrollView, StyleSheet, View, Modal as ReactModal, GestureResponderEvent, PressableStateCallbackType, StyleProp, ViewStyle } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { zIndexes } from '../../styles/z-index';
 import { modalPresentations } from '../../constants/constants';
 import { getColor } from '../../styles/colors';

--- a/src/components/UiPanel/index.tsx
+++ b/src/components/UiPanel/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { ViewProps, StyleProp, StyleSheet, ViewStyle, ScrollView, Modal as ReactModal, SafeAreaView, Pressable, View, Animated } from 'react-native';
+import { ViewProps, StyleProp, StyleSheet, ViewStyle, ScrollView, Modal as ReactModal, Pressable, View, Animated } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { getColor } from '../../styles/colors';
 import { styleReferenceBreaker } from '../../helpers';
 import { UiPanelItem, UiPanelItemProps } from '../UiPanelItem';

--- a/src/components/ViewWrapper/index.tsx
+++ b/src/components/ViewWrapper/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { ViewProps, StyleSheet, SafeAreaView, StatusBar, View } from 'react-native';
+import { ViewProps, StyleSheet, StatusBar, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { getColor, useDarkMode } from '../../styles/colors';
 import { BottomSafeAreaColorOverride } from '../BottomSafeAreaColorOverride';
 


### PR DESCRIPTION
This change is based on recommendations here https://github.com/react-native-community/discussions-and-proposals/discussions/827

https://developer.android.com/develop/ui/views/layout/display-cutout

Closes #195

BREAKING CHANGE: New peer dependency required.