### PR TITLE
Fixed the issue for Android:TextInput Does Not Align with Carbon Design Issue #229

### DIFF
--- a/src/components/BaseTextInputs/index.tsx
+++ b/src/components/BaseTextInputs/index.tsx
@@ -61,7 +61,6 @@ export const getTextInputStyle = (light?: boolean, hasLabelLink?: boolean, fullB
     borderColor: getColor('field01'),
     color: getColor('textPrimary'),
     borderBottomColor: getColor('borderStrong02'),
-    borderWidth: 2,
     borderBottomWidth: 1,
     paddingRight: 16,
     paddingLeft: 18,
@@ -128,6 +127,7 @@ export const getTextInputStyle = (light?: boolean, hasLabelLink?: boolean, fullB
       borderBottomColor: getColor('focus'),
       paddingRight: 14,
       borderBottomWidth: 2,
+      borderWidth: 2,
     },
     textBoxError: {
       ...baseTextBox,


### PR DESCRIPTION
This is PR for the fix #229 where for Android TextInput was not Aligning with Carbon Designs.

Please refer the Screenshots for the final result. I have tested both for Android and iOS on all the theme. 

This also fixed the border that was on Search inputs. 

<img width="1115" height="1035" alt="image" src="https://github.com/user-attachments/assets/07cebefb-c11c-487e-8076-c5d8afed33e1" />
